### PR TITLE
Upgrade to RTK 2 + React-Redux 9

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -21,11 +21,11 @@
     "@mui/material": "^6.5.0",
     "@mui/x-date-pickers": "^7.29.4",
     "@mui/x-date-pickers-pro": "^7.29.4",
-    "@reduxjs/toolkit": "^1.9.7",
+    "@reduxjs/toolkit": "^2.0.0",
     "dayjs": "^1.11.19",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-redux": "^8.1.3",
+    "react-redux": "^9.0.0",
     "react-router": "^7.7.0",
     "redux-persist": "^6.0.0"
   },

--- a/client/pnpm-lock.yaml
+++ b/client/pnpm-lock.yaml
@@ -32,8 +32,8 @@ importers:
         specifier: ^7.29.4
         version: 7.29.4(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1))(@types/react@18.3.27)(react@18.3.1))(@mui/material@6.5.0(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1))(@types/react@18.3.27)(react@18.3.1))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mui/system@7.3.7(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1))(@types/react@18.3.27)(react@18.3.1))(@types/react@18.3.27)(react@18.3.1))(@types/react@18.3.27)(dayjs@1.11.19)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@reduxjs/toolkit':
-        specifier: ^1.9.7
-        version: 1.9.7(react-redux@8.1.3(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@4.2.1))(react@18.3.1)
+        specifier: ^2.0.0
+        version: 2.11.2(react-redux@9.2.0(@types/react@18.3.27)(react@18.3.1)(redux@5.0.1))(react@18.3.1)
       dayjs:
         specifier: ^1.11.19
         version: 1.11.19
@@ -44,14 +44,14 @@ importers:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
       react-redux:
-        specifier: ^8.1.3
-        version: 8.1.3(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@4.2.1)
+        specifier: ^9.0.0
+        version: 9.2.0(@types/react@18.3.27)(react@18.3.1)(redux@5.0.1)
       react-router:
         specifier: ^7.7.0
         version: 7.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       redux-persist:
         specifier: ^6.0.0
-        version: 6.0.0(react@18.3.1)(redux@4.2.1)
+        version: 6.0.0(react@18.3.1)(redux@5.0.1)
     devDependencies:
       '@testing-library/jest-dom':
         specifier: ^6.9.1
@@ -2027,14 +2027,14 @@ packages:
         integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==,
       }
 
-  '@reduxjs/toolkit@1.9.7':
+  '@reduxjs/toolkit@2.11.2':
     resolution:
       {
-        integrity: sha512-t7v8ZPxhhKgOKtU+uyJT13lu4vL7az5aFi4IdoDs/eS548edn2M8Ik9h8fxgvMjGoAUVFSt6ZC1P5cWmQ014QQ==,
+        integrity: sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==,
       }
     peerDependencies:
-      react: ^16.9.0 || ^17.0.0 || ^18
-      react-redux: ^7.2.1 || ^8.0.2
+      react: ^16.9.0 || ^17.0.0 || ^18 || ^19
+      react-redux: ^7.2.1 || ^8.1.3 || ^9.0.0
     peerDependenciesMeta:
       react:
         optional: true
@@ -2253,6 +2253,18 @@ packages:
         integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==,
       }
 
+  '@standard-schema/spec@1.1.0':
+    resolution:
+      {
+        integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==,
+      }
+
+  '@standard-schema/utils@0.3.0':
+    resolution:
+      {
+        integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==,
+      }
+
   '@swc/core-darwin-arm64@1.15.11':
     resolution:
       {
@@ -2415,14 +2427,6 @@ packages:
         integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==,
       }
 
-  '@types/hoist-non-react-statics@3.3.7':
-    resolution:
-      {
-        integrity: sha512-PQTyIulDkIDro8P+IHbKCsw7U2xxBYflVzW/FgWdCAePD9xGSidgA76/GeJ6lBKoblyhf9pBY763gbrN+1dI8g==,
-      }
-    peerDependencies:
-      '@types/react': '*'
-
   '@types/parse-json@4.0.2':
     resolution:
       {
@@ -2457,10 +2461,10 @@ packages:
         integrity: sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==,
       }
 
-  '@types/use-sync-external-store@0.0.3':
+  '@types/use-sync-external-store@0.0.6':
     resolution:
       {
-        integrity: sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA==,
+        integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==,
       }
 
   '@typescript-eslint/eslint-plugin@8.54.0':
@@ -4188,10 +4192,10 @@ packages:
       }
     engines: { node: '>= 4' }
 
-  immer@9.0.21:
+  immer@11.1.3:
     resolution:
       {
-        integrity: sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA==,
+        integrity: sha512-6jQTc5z0KJFtr1UgFpIL3N9XSC3saRaI9PwWtzM2pSqkNGtiNkYY2OSwkOGDK2XcTRcLb1pi/aNkKZz0nxVH4Q==,
       }
 
   import-fresh@3.3.1:
@@ -5457,26 +5461,17 @@ packages:
         integrity: sha512-W+EWGn2v0ApPKgKKCy/7s7WHXkboGcsrXE+2joLyVxkbyVQfO3MUEaUQDHoSmb8TFFrSKYa9mw64WZHNHSDzYA==,
       }
 
-  react-redux@8.1.3:
+  react-redux@9.2.0:
     resolution:
       {
-        integrity: sha512-n0ZrutD7DaX/j9VscF+uTALI3oUPa/pO4Z3soOBIjuRn/FzVu6aehhysxZCLi6y7duMf52WNZGMl7CtuK5EnRw==,
+        integrity: sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==,
       }
     peerDependencies:
-      '@types/react': ^16.8 || ^17.0 || ^18.0
-      '@types/react-dom': ^16.8 || ^17.0 || ^18.0
-      react: ^16.8 || ^17.0 || ^18.0
-      react-dom: ^16.8 || ^17.0 || ^18.0
-      react-native: '>=0.59'
-      redux: ^4 || ^5.0.0-beta.0
+      '@types/react': ^18.2.25 || ^19
+      react: ^18.0 || ^19
+      redux: ^5.0.0
     peerDependenciesMeta:
       '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-      react-dom:
-        optional: true
-      react-native:
         optional: true
       redux:
         optional: true
@@ -5543,18 +5538,18 @@ packages:
       react:
         optional: true
 
-  redux-thunk@2.4.2:
+  redux-thunk@3.1.0:
     resolution:
       {
-        integrity: sha512-+P3TjtnP0k/FEjcBL5FZpoovtvrTNT/UXd4/sluaSyrURlSlhLSzEdfsTBW7WsKB6yPvgd7q/iZPICFjW4o57Q==,
+        integrity: sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==,
       }
     peerDependencies:
-      redux: ^4
+      redux: ^5.0.0
 
-  redux@4.2.1:
+  redux@5.0.1:
     resolution:
       {
-        integrity: sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==,
+        integrity: sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==,
       }
 
   reflect.getprototypeof@1.0.10:
@@ -5658,10 +5653,10 @@ packages:
         integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==,
       }
 
-  reselect@4.1.8:
+  reselect@5.1.1:
     resolution:
       {
-        integrity: sha512-ab9EmR80F/zQTMNeneUr4cv+jSwPJgIlvEmVwLerwrWVbpLlBuls9XHzIeTFy4cegU2NHBp3va0LKOzU5qFEYQ==,
+        integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==,
       }
 
   resolve-from@4.0.0:
@@ -8112,15 +8107,17 @@ snapshots:
 
   '@popperjs/core@2.11.8': {}
 
-  '@reduxjs/toolkit@1.9.7(react-redux@8.1.3(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@4.2.1))(react@18.3.1)':
+  '@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@18.3.27)(react@18.3.1)(redux@5.0.1))(react@18.3.1)':
     dependencies:
-      immer: 9.0.21
-      redux: 4.2.1
-      redux-thunk: 2.4.2(redux@4.2.1)
-      reselect: 4.1.8
+      '@standard-schema/spec': 1.1.0
+      '@standard-schema/utils': 0.3.0
+      immer: 11.1.3
+      redux: 5.0.1
+      redux-thunk: 3.1.0(redux@5.0.1)
+      reselect: 5.1.1
     optionalDependencies:
       react: 18.3.1
-      react-redux: 8.1.3(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@4.2.1)
+      react-redux: 9.2.0(@types/react@18.3.27)(react@18.3.1)(redux@5.0.1)
 
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
@@ -8200,6 +8197,10 @@ snapshots:
     optional: true
 
   '@sinclair/typebox@0.27.8': {}
+
+  '@standard-schema/spec@1.1.0': {}
+
+  '@standard-schema/utils@0.3.0': {}
 
   '@swc/core-darwin-arm64@1.15.11':
     optional: true
@@ -8298,11 +8299,6 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
-  '@types/hoist-non-react-statics@3.3.7(@types/react@18.3.27)':
-    dependencies:
-      '@types/react': 18.3.27
-      hoist-non-react-statics: 3.3.2
-
   '@types/parse-json@4.0.2': {}
 
   '@types/prop-types@15.7.15': {}
@@ -8320,7 +8316,7 @@ snapshots:
       '@types/prop-types': 15.7.15
       csstype: 3.2.3
 
-  '@types/use-sync-external-store@0.0.3': {}
+  '@types/use-sync-external-store@0.0.6': {}
 
   '@typescript-eslint/eslint-plugin@8.54.0(@typescript-eslint/parser@8.54.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)':
     dependencies:
@@ -9627,7 +9623,7 @@ snapshots:
 
   ignore@7.0.5: {}
 
-  immer@9.0.21: {}
+  immer@11.1.3: {}
 
   import-fresh@3.3.1:
     dependencies:
@@ -10374,20 +10370,14 @@ snapshots:
 
   react-is@19.2.4: {}
 
-  react-redux@8.1.3(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@4.2.1):
+  react-redux@9.2.0(@types/react@18.3.27)(react@18.3.1)(redux@5.0.1):
     dependencies:
-      '@babel/runtime': 7.28.6
-      '@types/hoist-non-react-statics': 3.3.7(@types/react@18.3.27)
-      '@types/use-sync-external-store': 0.0.3
-      hoist-non-react-statics: 3.3.2
+      '@types/use-sync-external-store': 0.0.6
       react: 18.3.1
-      react-is: 18.3.1
       use-sync-external-store: 1.6.0(react@18.3.1)
     optionalDependencies:
       '@types/react': 18.3.27
-      '@types/react-dom': 18.3.7(@types/react@18.3.27)
-      react-dom: 18.3.1(react@18.3.1)
-      redux: 4.2.1
+      redux: 5.0.1
 
   react-router@7.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
@@ -10429,19 +10419,17 @@ snapshots:
       indent-string: 4.0.0
       strip-indent: 3.0.0
 
-  redux-persist@6.0.0(react@18.3.1)(redux@4.2.1):
+  redux-persist@6.0.0(react@18.3.1)(redux@5.0.1):
     dependencies:
-      redux: 4.2.1
+      redux: 5.0.1
     optionalDependencies:
       react: 18.3.1
 
-  redux-thunk@2.4.2(redux@4.2.1):
+  redux-thunk@3.1.0(redux@5.0.1):
     dependencies:
-      redux: 4.2.1
+      redux: 5.0.1
 
-  redux@4.2.1:
-    dependencies:
-      '@babel/runtime': 7.28.6
+  redux@5.0.1: {}
 
   reflect.getprototypeof@1.0.10:
     dependencies:
@@ -10503,7 +10491,7 @@ snapshots:
 
   requires-port@1.0.0: {}
 
-  reselect@4.1.8: {}
+  reselect@5.1.1: {}
 
   resolve-from@4.0.0: {}
 

--- a/client/src/app/hooks.ts
+++ b/client/src/app/hooks.ts
@@ -1,0 +1,5 @@
+import { useDispatch, useSelector } from 'react-redux';
+import type { AppDispatch, RootState } from './store';
+
+export const useAppDispatch = useDispatch.withTypes<AppDispatch>();
+export const useAppSelector = useSelector.withTypes<RootState>();

--- a/client/src/features/appointments/apptApiSlice.ts
+++ b/client/src/features/appointments/apptApiSlice.ts
@@ -6,15 +6,13 @@ import { Appointment } from '../../types';
 import type { RootState } from '../../app/store';
 
 
-const appointmentAdapter = createEntityAdapter<Appointment>({
-  selectId: (appt) => appt.id,
-});
+const appointmentAdapter = createEntityAdapter<Appointment>();
 
 const initialState = appointmentAdapter.getInitialState();
 
 export const extendedApiSlice = apiSlice.injectEndpoints({
   endpoints: (builder) => ({
-    getAppointment: builder.query<EntityState<Appointment>, void>({
+    getAppointment: builder.query<EntityState<Appointment, string>, void>({
       query: () => '/api/appointments',
       transformResponse: (responseData: Appointment[]) => {
         const loadedPosts = responseData

--- a/client/src/features/employeeSlice.ts
+++ b/client/src/features/employeeSlice.ts
@@ -13,15 +13,13 @@ export interface Employee {
   bio?: string;
 }
 
-const employeeAdapter = createEntityAdapter<Employee>({
-  selectId: (employee) => employee.id,
-});
+const employeeAdapter = createEntityAdapter<Employee>();
 
 const initialState = employeeAdapter.getInitialState();
 
 export const extendedApiSlice = apiSlice.injectEndpoints({
   endpoints: (builder) => ({
-    getEmployees: builder.query<EntityState<Employee>, void>({
+    getEmployees: builder.query<EntityState<Employee, string>, void>({
       query: () => '/api/employees',
       transformResponse: (responseData: Employee[]) => {
         return employeeAdapter.setAll(initialState, responseData);

--- a/client/src/features/scheduleSlice.ts
+++ b/client/src/features/scheduleSlice.ts
@@ -13,15 +13,13 @@ import {
 } from '../utils/date';
 import { Schedule } from '../types';
 
-const scheduleAdapter = createEntityAdapter<Schedule>({
-  selectId: (schedule) => schedule.id,
-});
+const scheduleAdapter = createEntityAdapter<Schedule>();
 
 const initialState = scheduleAdapter.getInitialState();
 
 export const extendedApiSlice = apiSlice.injectEndpoints({
   endpoints: (builder) => ({
-    getSchedule: builder.query<EntityState<Schedule>, void>({
+    getSchedule: builder.query<EntityState<Schedule, string>, void>({
       query: () => '/api/schedules',
       transformResponse: (responseData: Schedule[]) => {
         const loadedPosts = responseData

--- a/client/src/features/userSlice.ts
+++ b/client/src/features/userSlice.ts
@@ -10,9 +10,7 @@ export interface User {
   role: string;
 }
 
-const userAdapter = createEntityAdapter<User>({
-  selectId: (user) => user.id,
-});
+const userAdapter = createEntityAdapter<User>();
 
 const initialState = userAdapter.getInitialState();
 

--- a/client/src/hooks/useAppointment.ts
+++ b/client/src/hooks/useAppointment.ts
@@ -1,4 +1,4 @@
-import { useDispatch, useSelector } from 'react-redux';
+import { useAppDispatch, useAppSelector } from '@/app/hooks';
 import { useNavigate, useLocation } from 'react-router';
 import {
   useCancelAppointmentMutation,
@@ -13,11 +13,11 @@ import {
 import { useNotification } from '@/hooks/useNotification';
 
 export function useAppointment() {
-  const dispatch = useDispatch();
+  const dispatch = useAppDispatch();
   const navigate = useNavigate();
   const location = useLocation();
-  const rescheduling = useSelector(selectRescheduling);
-  const modifyingApptId = useSelector(selectModifyingApptId);
+  const rescheduling = useAppSelector(selectRescheduling);
+  const modifyingApptId = useAppSelector(selectModifyingApptId);
   const [cancelAppointment] = useCancelAppointmentMutation();
   const [updateAppointmentStatus] = useUpdateAppointmentStatusMutation();
   const { handleSuccess, handleError } = useNotification();

--- a/client/src/hooks/useAuth.ts
+++ b/client/src/hooks/useAuth.ts
@@ -1,4 +1,4 @@
-import { useDispatch, useSelector } from 'react-redux';
+import { useAppDispatch, useAppSelector } from '@/app/hooks';
 import { useNavigate, useLocation } from 'react-router';
 import {
   useLoginMutation,
@@ -34,10 +34,10 @@ interface PasswordResetPayload {
 }
 
 export function useAuth() {
-  const dispatch = useDispatch();
+  const dispatch = useAppDispatch();
   const navigate = useNavigate();
-  const user = useSelector(selectCurrentUser);
-  const role = useSelector(selectCurrentUserRole);
+  const user = useAppSelector(selectCurrentUser);
+  const role = useAppSelector(selectCurrentUserRole);
   const [login] = useLoginMutation();
   const [logout] = useLogoutMutation();
   const [changeUserEmail] = useChangeUserEmailMutation();

--- a/client/src/hooks/useEmployeesQuery.ts
+++ b/client/src/hooks/useEmployeesQuery.ts
@@ -1,15 +1,13 @@
-import { useSelector } from 'react-redux';
+import { useAppSelector } from '@/app/hooks';
 import {
   selectAllEmployees,
   selectEmployeeById,
   useGetEmployeesQuery,
 } from '@/features/employeeSlice';
-import type { RootState } from '@/app/store';
-
 export function useEmployeesQuery(employeeId?: string) {
   useGetEmployeesQuery();
-  const employees = useSelector(selectAllEmployees);
-  const employee = useSelector((state: RootState) =>
+  const employees = useAppSelector(selectAllEmployees);
+  const employee = useAppSelector((state) =>
     employeeId ? selectEmployeeById(state, employeeId) : null
   );
 

--- a/client/src/hooks/useFilter.ts
+++ b/client/src/hooks/useFilter.ts
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useAppDispatch, useAppSelector } from '@/app/hooks';
 import { Dayjs } from 'dayjs';
 import {
   resetFilter,
@@ -15,13 +15,13 @@ import { services } from '@/data/data';
 import { Slot, Employee } from '@/types';
 
 export function useFilter() {
-  const dispatch = useDispatch();
+  const dispatch = useAppDispatch();
 
   const { employees } = useEmployeesQuery();
   const [selection, setSelection] = useState<Slot | Record<string, never>>({});
-  const date = useSelector(selectDate);
-  const employee = useSelector(selectEmployee);
-  const service = useSelector(selectService);
+  const date = useAppSelector(selectDate);
+  const employee = useAppSelector(selectEmployee);
+  const service = useAppSelector(selectService);
 
   const handleDateChange = (newDate: Dayjs) => {
     dispatch(setDate(newDate.toISOString()));

--- a/client/src/hooks/useNotification.ts
+++ b/client/src/hooks/useNotification.ts
@@ -1,4 +1,4 @@
-import { useDispatch, useSelector } from 'react-redux';
+import { useAppDispatch, useAppSelector } from '@/app/hooks';
 import {
   selectOpen,
   selectMessage,
@@ -10,10 +10,10 @@ import {
 import { getErrorMessage } from '@/utils/apiError';
 
 export function useNotification() {
-  const dispatch = useDispatch();
-  const open = useSelector(selectOpen);
-  const message = useSelector(selectMessage);
-  const severity = useSelector(selectSeverity);
+  const dispatch = useAppDispatch();
+  const open = useAppSelector(selectOpen);
+  const message = useAppSelector(selectMessage);
+  const severity = useAppSelector(selectSeverity);
   const handleSuccess = (msg: string) => dispatch(setSuccess(msg));
   const handleError = (err: unknown, extraErr?: unknown) => {
     const errorMessage = getErrorMessage(err);

--- a/client/src/hooks/useScheduleQuery.ts
+++ b/client/src/hooks/useScheduleQuery.ts
@@ -1,4 +1,4 @@
-import { useSelector } from "react-redux";
+import { useAppSelector } from "@/app/hooks";
 import {
   selectAllSchedule,
   selectScheduleById,
@@ -6,12 +6,10 @@ import {
 } from "@/features/scheduleSlice";
 
 import { normalizeAppointments, splitByUpcomingAndPast } from "@/utils/date";
-import type { RootState } from "@/app/store";
-
 export function useScheduleQuery(scheduleId?: string) {
   useGetScheduleQuery();
-  const schedules = useSelector(selectAllSchedule);
-  const schedule = useSelector((state: RootState) =>
+  const schedules = useAppSelector(selectAllSchedule);
+  const schedule = useAppSelector((state) =>
     scheduleId ? selectScheduleById(state, scheduleId) : null,
   );
   const appointments = schedule

--- a/client/src/hooks/useUsersQuery.ts
+++ b/client/src/hooks/useUsersQuery.ts
@@ -1,13 +1,11 @@
-import { useSelector } from 'react-redux';
+import { useAppSelector } from '@/app/hooks';
 import {
   selectUserById,
   useGetUsersQuery,
 } from '@/features/userSlice';
-import type { RootState } from '@/app/store';
-
 export function useUsersQuery(userId: string) {
   useGetUsersQuery();
-  const user = useSelector((state: RootState) => selectUserById(state, userId));
+  const user = useAppSelector((state) => selectUserById(state, userId));
 
   return { user };
 }

--- a/client/src/routes/Appointments/index.tsx
+++ b/client/src/routes/Appointments/index.tsx
@@ -1,4 +1,4 @@
-import { useSelector } from 'react-redux';
+import { useAppSelector } from '@/app/hooks';
 import { Link } from 'react-router';
 import {
   selectAllAppointment,
@@ -14,7 +14,7 @@ import { Appointment } from '@/types';
 // This is the user's Appointments page when accessed through the Profile
 export default function Appointments() {
   useGetAppointmentQuery();
-  const appointments = useSelector(selectAllAppointment);
+  const appointments = useAppSelector(selectAllAppointment);
 
   let content;
 

--- a/client/src/routes/BookingPage/EmployeeRadio.tsx
+++ b/client/src/routes/BookingPage/EmployeeRadio.tsx
@@ -1,4 +1,4 @@
-import { useSelector } from 'react-redux';
+import { useAppSelector } from '@/app/hooks';
 import Radio from '@mui/material/Radio';
 import RadioGroup from '@mui/material/RadioGroup';
 import FormControlLabel from '@mui/material/FormControlLabel';
@@ -7,14 +7,12 @@ import FormLabel from '@mui/material/FormLabel';
 
 import { selectEmployeeById } from '@/features/employeeSlice';
 import { useFilter } from '@/hooks/useFilter';
-import type { RootState } from '@/app/store';
-
 interface EmployeeRadioOptionProps {
   employeeId: string;
 }
 
 const EmployeeRadioOption = ({ employeeId }: EmployeeRadioOptionProps) => {
-  const employee = useSelector((state: RootState) =>
+  const employee = useAppSelector((state) =>
     selectEmployeeById(state, employeeId)
   );
 

--- a/client/src/routes/BookingPage/EmployeeSelect/index.tsx
+++ b/client/src/routes/BookingPage/EmployeeSelect/index.tsx
@@ -1,4 +1,4 @@
-import { useSelector } from 'react-redux';
+import { useAppSelector } from '@/app/hooks';
 import FormControl from '@mui/material/FormControl';
 import InputLabel from '@mui/material/InputLabel';
 import MenuItem from '@mui/material/MenuItem';
@@ -9,7 +9,7 @@ import { useFilter } from '@/hooks/useFilter';
 import { theme } from '@/styles/styles';
 
 export default function EmployeeSelect() {
-  const employees = useSelector(selectAllEmployees);
+  const employees = useAppSelector(selectAllEmployees);
   const { employee, handleEmployeeChange } = useFilter();
 
   const employeeId = employee?.id;

--- a/client/src/test/test-utils.tsx
+++ b/client/src/test/test-utils.tsx
@@ -1,7 +1,7 @@
 import { ReactElement, ReactNode } from 'react';
 import { render, RenderOptions } from '@testing-library/react';
 import { Provider } from 'react-redux';
-import { configureStore } from '@reduxjs/toolkit';
+import { configureStore, combineReducers } from '@reduxjs/toolkit';
 import { MemoryRouter } from 'react-router';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
@@ -20,14 +20,16 @@ interface ExtendedRenderOptions extends Omit<RenderOptions, 'queries'> {
 }
 
 export function createTestStore(preloadedState: Record<string, unknown> = {}) {
+  const rootReducer = combineReducers({
+    [apiSlice.reducerPath]: apiSlice.reducer,
+    appointment: appointmentReducer,
+    auth: authReducer,
+    filter: filterReducer,
+    notification: notificationReducer,
+  });
+
   return configureStore({
-    reducer: {
-      [apiSlice.reducerPath]: apiSlice.reducer,
-      appointment: appointmentReducer,
-      auth: authReducer,
-      filter: filterReducer,
-      notification: notificationReducer,
-    },
+    reducer: rootReducer,
     preloadedState,
     middleware: (getDefaultMiddleware) =>
       getDefaultMiddleware({

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "@playwright/test": "^1.58.1",
     "husky": "^9.1.7",
     "lint-staged": "^15.5.2",
-    "prettier": "^3.8.1"
+    "prettier": "^3.8.1",
+    "typescript": "^5.9.3"
   },
   "lint-staged": {
     "server/src/**/*.{ts,tsx}": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,9 @@ importers:
       prettier:
         specifier: ^3.8.1
         version: 3.8.1
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
 
 packages:
   '@playwright/test@1.58.1':
@@ -433,6 +436,14 @@ packages:
       }
     engines: { node: '>=8.0' }
 
+  typescript@5.9.3:
+    resolution:
+      {
+        integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==,
+      }
+    engines: { node: '>=14.17' }
+    hasBin: true
+
   which@2.0.2:
     resolution:
       {
@@ -662,6 +673,8 @@ snapshots:
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
+
+  typescript@5.9.3: {}
 
   which@2.0.2:
     dependencies:


### PR DESCRIPTION
Upgrades Redux Toolkit from v1.9.7 to v2.0.0 and react-redux from v8.1.3 to v9.0.0.

## Changes
- Bump @reduxjs/toolkit to ^2.0.0
- Bump react-redux to ^9.0.0
- Remove deprecated selectId option from createEntityAdapter
- Fix EntityState<T> to EntityState<T, Id> (2 type arguments)
- Fix test-utils.tsx to use combineReducers for type-safe reducer object

## Test Results
- ✅ Typecheck: Passed
- ✅ Lint: Passed
- ✅ Client tests: 20/20 passed

## Notes
- Middleware already used callback form (no changes needed)
- No extraReducers to convert (already using builder pattern)
