### PR TITLE
refactor(domain): centralize shared booking contracts

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -19,6 +19,7 @@
     "@emotion/styled": "^11.14.1",
     "@fvilers/disable-react-devtools": "^1.3.0",
     "@convex-dev/better-auth": "^0.10.10",
+    "@cut-above/shared": "workspace:*",
     "@mui/icons-material": "^6.5.0",
     "@mui/material": "^6.5.0",
     "@mui/x-date-pickers": "^7.29.4",

--- a/client/pnpm-lock.yaml
+++ b/client/pnpm-lock.yaml
@@ -10,6 +10,9 @@ importers:
       '@convex-dev/better-auth':
         specifier: ^0.10.10
         version: 0.10.10(@better-auth/core@1.4.9(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.7(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.0))(@better-auth/utils@0.3.0)(@standard-schema/spec@1.1.0)(better-auth@1.4.9(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@1.6.1(jsdom@24.1.3)))(better-call@1.1.7(zod@4.3.6))(convex@1.31.7(react@19.2.4))(nanostores@1.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+      '@cut-above/shared':
+        specifier: workspace:*
+        version: link:../shared
       '@date-io/dayjs':
         specifier: ^2.17.0
         version: 2.17.0(dayjs@1.11.19)

--- a/client/src/features/appointments/apptApiSlice.ts
+++ b/client/src/features/appointments/apptApiSlice.ts
@@ -193,7 +193,7 @@ export const useModifyManagedAppointmentMutation = () => {
 export const useUpdateAppointmentStatusMutation = () => {
   const updateStatus = useMutation(api.appointments.updateAppointmentStatus);
 
-  const trigger = async (payload: { id: string; status: string }) => {
+  const trigger = async (payload: { id: string; status: Appointment['status'] }) => {
     return updateStatus(payload);
   };
 

--- a/client/src/hooks/useAppointment.ts
+++ b/client/src/hooks/useAppointment.ts
@@ -11,6 +11,7 @@ import {
 } from '@/features/appointments/appointmentSlice';
 
 import { useNotification } from '@/hooks/useNotification';
+import type { Appointment } from '@/types';
 
 export function useAppointment() {
   const dispatch = useAppDispatch();
@@ -44,7 +45,7 @@ export function useAppointment() {
 
   const handleEndRescheduling = () => dispatch(endRescheduling());
 
-  const handleStatusUpdate = async (id: string, newStatus: string) => {
+  const handleStatusUpdate = async (id: string, newStatus: Appointment['status']) => {
     try {
       const statusUpdate = await updateAppointmentStatus({
         id,

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -1,5 +1,7 @@
 import { Dayjs } from "dayjs";
 
+import type { AppointmentStatus, ServiceName } from "@cut-above/shared";
+
 export interface GenericResponse {
   success: boolean;
   message: string;
@@ -25,15 +27,8 @@ export interface Appointment {
   start: string;
   end?: string;
   duration?: number;
-  status:
-    | "scheduled"
-    | "cancelled"
-    | "attended"
-    | "not-attended"
-    | "checked-in"
-    | "completed"
-    | string;
-  service: string;
+  status: AppointmentStatus | "attended" | "not-attended" | string;
+  service: ServiceName | string;
   customerName?: string;
   customerEmail?: string;
 }

--- a/convex-tests/src/appointmentAccess.test.ts
+++ b/convex-tests/src/appointmentAccess.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest';
 import { api, components } from '../../convex/_generated/api';
 import { createConvexTest } from './convexTest';
 
-const service = 'Cut';
+const service = 'Haircut';
 
 const extractTokenFromLink = (emailLink: string) => {
   const parsedUrl = new URL(emailLink);
@@ -190,7 +190,7 @@ describe('appointment manage access links', () => {
         token,
         start: '2027-02-02T17:00:00.000Z',
         end: '2027-02-02T18:00:00.000Z',
-        service: 'Line Up',
+        service: 'Beard Trim',
         employee: { id: employeeId, firstName: 'Pat' },
       });
 
@@ -215,7 +215,7 @@ describe('appointment manage access links', () => {
         }
       );
 
-      expect(appointment.service).toBe('Line Up');
+      expect(appointment.service).toBe('Beard Trim');
       expect(appointment.start).toBe('2027-02-02T17:00:00.000Z');
     }
   );

--- a/convex-tests/src/appointments.test.ts
+++ b/convex-tests/src/appointments.test.ts
@@ -6,7 +6,7 @@ import { createConvexTest } from './convexTest';
 const scheduleDate = '2026-02-02';
 const scheduleId = 'schedule-1';
 const employeeId = 'employee-1';
-const service = 'Cut';
+const service = 'Haircut';
 const startTime = '2026-02-02T15:00:00.000Z';
 const endTime = '2026-02-02T16:00:00.000Z';
 
@@ -101,6 +101,21 @@ const seedSchedule = async (t: ReturnType<typeof createConvexTest>) => {
   });
 };
 
+const seedAppointment = async (t: ReturnType<typeof createConvexTest>) => {
+  await t.run(async (ctx) => {
+    await ctx.db.insert('appointments', {
+      id: 'existing-appt',
+      status: 'scheduled',
+      service,
+      start: startTime,
+      end: endTime,
+      clientId: 'client-1',
+      employeeId,
+      scheduleId,
+    });
+  });
+};
+
 describe('appointments.createAppointment', () => {
   it(
     'rejects conflicting bookings for the same employee',
@@ -111,18 +126,7 @@ describe('appointments.createAppointment', () => {
       await seedEmployee(t);
       const client = await createAuthUser(t, 'client');
 
-      await t.run(async (ctx) => {
-        await ctx.db.insert('appointments', {
-          id: 'existing-appt',
-          status: 'scheduled',
-          service,
-          start: startTime,
-          end: endTime,
-          clientId: 'client-1',
-          employeeId,
-          scheduleId,
-        });
-      });
+      await seedAppointment(t);
 
       const asClient = t.withIdentity(client.identity);
       await expect(
@@ -227,4 +231,39 @@ describe('appointments.createAppointment', () => {
       ).resolves.toMatchObject({ success: true });
     }
   );
+
+  it('rejects services outside the shared booking contract', async () => {
+    const t = createConvexTest();
+    await seedSchedule(t);
+    await seedEmployee(t);
+    const client = await createAuthUser(t, 'client');
+
+    const asClient = t.withIdentity(client.identity);
+    await expect(
+      asClient.mutation(api.appointments.createAppointment, {
+        start: startTime,
+        end: endTime,
+        service: 'Cut' as never,
+        employee: { id: employeeId, firstName: 'Pat' },
+      })
+    ).rejects.toThrow(/Validator error/);
+  });
+});
+
+describe('appointments.updateAppointmentStatus', () => {
+  it('rejects statuses outside the shared booking contract', async () => {
+    const t = createConvexTest();
+    await seedSchedule(t);
+    await seedEmployee(t);
+    await seedAppointment(t);
+    const admin = await createAuthUser(t, 'admin');
+
+    const asAdmin = t.withIdentity(admin.identity);
+    await expect(
+      asAdmin.mutation(api.appointments.updateAppointmentStatus, {
+        id: 'existing-appt',
+        status: 'invalid-status' as never,
+      })
+    ).rejects.toThrow(/Validator error/);
+  });
 });

--- a/convex-tests/src/seedMaintenance.test.ts
+++ b/convex-tests/src/seedMaintenance.test.ts
@@ -61,7 +61,7 @@ describe('seed.clearSeedData', () => {
       const now = Date.now();
       await ctx.db.insert('emailOutbox', {
         id: 'seed-outbox-1',
-        eventType: 'seed.test',
+        eventType: 'appointment.confirmation',
         dedupeKey: 'seed-dedupe',
         payload: { receiver: 'john.smith@cutabove.test' },
         status: 'pending',
@@ -79,7 +79,7 @@ describe('seed.clearSeedData', () => {
       });
       await ctx.db.insert('emailOutbox', {
         id: 'keep-outbox-1',
-        eventType: 'seed.keep',
+        eventType: 'contact.submission',
         dedupeKey: 'keep-dedupe',
         payload: { receiver: 'keep@cutabove.test' },
         status: 'pending',
@@ -92,7 +92,7 @@ describe('seed.clearSeedData', () => {
       for (let index = 0; index < extraSeedRows; index += 1) {
         await ctx.db.insert('emailOutbox', {
           id: `seed-outbox-extra-${index}`,
-          eventType: 'seed.test',
+          eventType: 'appointment.confirmation',
           dedupeKey: `seed-dedupe-extra-${index}`,
           payload: { receiver: 'john.smith@cutabove.test' },
           status: 'pending',

--- a/convex/appointments.ts
+++ b/convex/appointments.ts
@@ -2,11 +2,14 @@ import { ConvexError, v } from "convex/values";
 
 import type { Doc } from "./_generated/dataModel";
 import { mutation, query } from "./_generated/server";
-import { extractDateFromISO } from "./lib/dateTime";
+import {
+  appointmentStatusValidator,
+  serviceNameValidator,
+} from "./lib/domainValidators";
 import {
   assertAppointmentAccess,
-  assertRoleAllowed,
   assertAvailable,
+  assertRoleAllowed,
   buildAppointmentResponse,
   cancelAppointmentRecord,
   employeeInput,
@@ -22,6 +25,7 @@ import {
   requireAppointmentAccessToken,
   throwInvalidAppointmentAccess,
 } from "./lib/appointmentAccess";
+import { extractDateFromISO } from "./lib/dateTime";
 import { enqueueAppointmentEmail } from "./lib/emailOutbox";
 import { requireAdmin, requireAuthUser } from "./lib/auth";
 
@@ -129,7 +133,7 @@ export const createAppointment = mutation({
   args: {
     start: v.string(),
     end: v.string(),
-    service: v.string(),
+    service: serviceNameValidator,
     employee: employeeInput,
   },
   handler: async (ctx, args) => {
@@ -184,8 +188,8 @@ export const modifyAppointment = mutation({
     id: v.string(),
     start: v.optional(v.string()),
     end: v.optional(v.string()),
-    service: v.optional(v.string()),
-    status: v.optional(v.string()),
+    service: v.optional(serviceNameValidator),
+    status: v.optional(appointmentStatusValidator),
     employee: v.optional(employeeInput),
   },
   handler: async (ctx, args) => {
@@ -226,7 +230,7 @@ export const modifyManagedAppointmentByToken = mutation({
     token: v.string(),
     start: v.optional(v.string()),
     end: v.optional(v.string()),
-    service: v.optional(v.string()),
+    service: v.optional(serviceNameValidator),
     employee: v.optional(employeeInput),
   },
   handler: async (ctx, args) => {
@@ -261,7 +265,7 @@ export const modifyManagedAppointmentByToken = mutation({
 export const updateAppointmentStatus = mutation({
   args: {
     id: v.string(),
-    status: v.string(),
+    status: appointmentStatusValidator,
   },
   handler: async (ctx, args) => {
     await requireAdmin(ctx);

--- a/convex/lib/domainValidators.ts
+++ b/convex/lib/domainValidators.ts
@@ -1,0 +1,19 @@
+import { v } from "convex/values";
+import {
+  APPOINTMENT_STATUSES,
+  EMAIL_DELIVERY_STATUSES,
+  EMAIL_EVENT_TYPES,
+  EMAIL_OUTBOX_STATUSES,
+  ROLES,
+  SERVICE_NAMES,
+} from "@cut-above/shared";
+
+const literalUnion = <T extends readonly string[]>(values: T) =>
+  v.union(...values.map((value) => v.literal(value)));
+
+export const roleValidator = literalUnion(ROLES);
+export const appointmentStatusValidator = literalUnion(APPOINTMENT_STATUSES);
+export const serviceNameValidator = literalUnion(SERVICE_NAMES);
+export const emailOutboxStatusValidator = literalUnion(EMAIL_OUTBOX_STATUSES);
+export const emailDeliveryStatusValidator = literalUnion(EMAIL_DELIVERY_STATUSES);
+export const emailEventTypeValidator = literalUnion(EMAIL_EVENT_TYPES);

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -1,6 +1,15 @@
 import { defineSchema, defineTable } from 'convex/server';
 import { v } from 'convex/values';
 
+import {
+  appointmentStatusValidator,
+  emailDeliveryStatusValidator,
+  emailEventTypeValidator,
+  emailOutboxStatusValidator,
+  roleValidator,
+  serviceNameValidator,
+} from "./lib/domainValidators";
+
 export default defineSchema({
   users: defineTable({
     id: v.string(),
@@ -8,7 +17,7 @@ export default defineSchema({
     firstName: v.optional(v.string()),
     lastName: v.optional(v.string()),
     email: v.string(),
-    role: v.string(),
+    role: roleValidator,
     createdAt: v.optional(v.number()),
     updatedAt: v.optional(v.number()),
   })
@@ -26,8 +35,8 @@ export default defineSchema({
     .index('by_open', ['open']),
   appointments: defineTable({
     id: v.string(),
-    status: v.string(),
-    service: v.string(),
+    status: appointmentStatusValidator,
+    service: serviceNameValidator,
     start: v.string(),
     end: v.string(),
     clientId: v.string(),
@@ -50,10 +59,10 @@ export default defineSchema({
     .index('by_appointment_id', ['appointmentId']),
   emailOutbox: defineTable({
     id: v.string(),
-    eventType: v.string(),
+    eventType: emailEventTypeValidator,
     dedupeKey: v.string(),
     payload: v.any(),
-    status: v.string(),
+    status: emailOutboxStatusValidator,
     attempts: v.number(),
     availableAt: v.number(),
     createdAt: v.number(),
@@ -65,7 +74,7 @@ export default defineSchema({
   emailDeliveries: defineTable({
     id: v.string(),
     dedupeKey: v.string(),
-    status: v.string(),
+    status: emailDeliveryStatusValidator,
     providerMessageId: v.optional(v.string()),
     createdAt: v.number(),
     updatedAt: v.number(),

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "test:e2e": "playwright test"
   },
   "dependencies": {
+    "@cut-above/shared": "workspace:*",
     "dayjs": "^1.11.19",
     "nodemailer": "^6.10.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,9 @@ settings:
 importers:
   .:
     dependencies:
+      '@cut-above/shared':
+        specifier: workspace:*
+        version: link:shared
       dayjs:
         specifier: ^1.11.19
         version: 1.11.19

--- a/shared/src/domain/appointment.ts
+++ b/shared/src/domain/appointment.ts
@@ -1,0 +1,19 @@
+export const SERVICE_NAMES = [
+  "Haircut",
+  "Beard Trim",
+  "Straight Razor Shave",
+  "Cut and Shave Package",
+  "The Full Package",
+] as const;
+
+export type ServiceName = (typeof SERVICE_NAMES)[number];
+
+export const APPOINTMENT_STATUSES = [
+  "scheduled",
+  "cancelled",
+  "checked-in",
+  "completed",
+  "no show",
+] as const;
+
+export type AppointmentStatus = (typeof APPOINTMENT_STATUSES)[number];

--- a/shared/src/domain/auth.ts
+++ b/shared/src/domain/auth.ts
@@ -1,0 +1,3 @@
+export const ROLES = ["client", "employee", "admin"] as const;
+
+export type Role = (typeof ROLES)[number];

--- a/shared/src/domain/email.ts
+++ b/shared/src/domain/email.ts
@@ -1,0 +1,22 @@
+export const EMAIL_OUTBOX_STATUSES = [
+  "pending",
+  "processing",
+  "sent",
+  "failed",
+] as const;
+
+export type EmailOutboxStatus = (typeof EMAIL_OUTBOX_STATUSES)[number];
+
+export const EMAIL_DELIVERY_STATUSES = ["sending", "sent", "failed"] as const;
+
+export type EmailDeliveryStatus = (typeof EMAIL_DELIVERY_STATUSES)[number];
+
+export const EMAIL_EVENT_TYPES = [
+  "appointment.confirmation",
+  "appointment.modification",
+  "appointment.cancellation",
+  "contact.auto_reply",
+  "contact.submission",
+] as const;
+
+export type EmailEventType = (typeof EMAIL_EVENT_TYPES)[number];

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -1,3 +1,6 @@
+export * from './domain/auth.js';
+export * from './domain/appointment.js';
+export * from './domain/email.js';
 export * from './schemas/authSchema.js';
 export * from './schemas/appointmentSchema.js';
 export * from './schemas/emailSchema.js';

--- a/shared/src/schemas/appointmentSchema.ts
+++ b/shared/src/schemas/appointmentSchema.ts
@@ -1,5 +1,7 @@
 import * as v from 'valibot';
 
+import { APPOINTMENT_STATUSES, SERVICE_NAMES } from '../domain/appointment.js';
+
 const isoDatetime = v.pipe(
   v.string(),
   v.isoTimestamp(),
@@ -17,13 +19,7 @@ export const bookingSchema = v.pipe(
       id: v.pipe(v.string(), v.uuid()),
       firstName: v.string(),
     }),
-    service: v.picklist([
-      'Haircut',
-      'Beard Trim',
-      'Straight Razor Shave',
-      'Cut and Shave Package',
-      'The Full Package',
-    ]),
+    service: v.picklist(SERVICE_NAMES),
   }),
   v.check(
     (value) => new Date(value.end) > new Date(value.start),
@@ -32,7 +28,7 @@ export const bookingSchema = v.pipe(
 );
 
 export const statusSchema = v.object({
-  status: v.picklist(['scheduled', 'checked-in', 'completed', 'no show']),
+  status: v.picklist(APPOINTMENT_STATUSES),
 });
 
 export const idSchema = v.object({


### PR DESCRIPTION
## Summary
- centralize shared domain literals for roles, services, appointment statuses, and email event/status values
- align shared booking schema and client appointment types with those shared contracts
- tighten key Convex schema validators to use shared domain validators
- fix a stale BookingPage route test that was already broken on main

## Why
- reduce string drift between client, shared schema, and Convex backend
- establish a single source of truth before structured errors and appointment extraction work
- make future backend/domain cleanup safer and less ad hoc

## Changes
- added `shared/src/domain/auth.ts`
- added `shared/src/domain/appointment.ts`
- added `shared/src/domain/email.ts`
- exported new shared domain modules from `shared/src/index.ts`
- updated `shared/src/schemas/appointmentSchema.ts` to consume shared literals
- updated `client/src/types/index.ts` to use shared appointment/service types
- added `convex/lib/domainValidators.ts`
- tightened `convex/schema.ts` validators for role, appointment status, service, and email status/event fields
- updated BookingPage route test copy to match current UI
- updated root lockfile to reflect the `@cut-above/shared` workspace dependency

## Validation
- [x] `pnpm -C shared build`
- [x] `pnpm -C client typecheck`
- [x] `pnpm -C client test:run -- routes.test.tsx`

## Notes
- the failing BookingPage route test was confirmed broken on `origin/main` before this PR; this PR folds in the stale assertion fix instead of leaving the suite red
- left `emailOutbox.payload` as-is for now; typed payload modeling should happen in a later PR to keep this one scoped

## Follow-ups
- PR 2: structured backend/domain errors
- PR 3: appointment handler extraction and boundary cleanup