### PR TITLE
feat: add employee availability scheduling

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -29,6 +29,7 @@ const ManageAppointmentError = lazy(() => import('./routes/ManageAppointment/err
 const Appointments = lazy(() => import('./routes/Appointments'));
 const AddSchedule = lazy(() => import('./routes/AddSchedule'));
 const DashboardSchedule = lazy(() => import('./routes/DashboardSchedule'));
+const EmployeeAvailability = lazy(() => import('./routes/EmployeeAvailability'));
 const DashboardAppointment = lazy(
   () => import('./routes/DashboardAppointment')
 );
@@ -96,6 +97,7 @@ const router = createBrowserRouter(
               children: [
                 { index: true, element: <Account /> },
                 { path: 'settings', element: <Settings /> },
+                { path: 'availability', element: <EmployeeAvailability /> },
                 { path: 'appointments', element: <Appointments /> },
                 {
                   path: 'appointments/:id',

--- a/client/src/features/employeeSlice.ts
+++ b/client/src/features/employeeSlice.ts
@@ -8,6 +8,7 @@ import { useAppDispatch } from '@/app/hooks';
 export interface Employee {
   id: string;
   firstName: string;
+  lastName?: string;
 }
 
 const employeeAdapter = createEntityAdapter<Employee>();
@@ -55,4 +56,3 @@ export const useGetEmployeesQuery = () => {
     isError: false,
   };
 };
-

--- a/client/src/routes/Account/index.tsx
+++ b/client/src/routes/Account/index.tsx
@@ -21,6 +21,16 @@ export default function Account() {
         'Update your profile details, email, password, and account preferences.',
       to: 'settings',
     },
+    ...((isAdmin || role === 'employee')
+      ? [
+          {
+            title: 'Manage availability',
+            description:
+              'Set weekly hours, exceptions, and break windows without changing the core booking flow.',
+            to: 'availability',
+          },
+        ]
+      : []),
     ...(!isAdmin
       ? [
           {

--- a/client/src/routes/EmployeeAvailability/AdminDateViewSection.tsx
+++ b/client/src/routes/EmployeeAvailability/AdminDateViewSection.tsx
@@ -1,0 +1,155 @@
+import { Fragment, useMemo, useState } from 'react';
+import dayjs from 'dayjs';
+import Button from '@mui/material/Button';
+
+import { useQuery } from '@/convex/client';
+import { formatDateToTime } from '@/utils/date';
+import { api } from '../../../../convex/_generated/api';
+
+import styles from './styles.module.css';
+import { formatEmployeeName } from './shared';
+
+const formatCellBreaks = (
+  breaks: Array<{ start: string; end: string; label?: string }>
+) =>
+  breaks
+    .map(
+      (entry) =>
+        `${formatDateToTime(entry.start)}-${formatDateToTime(entry.end)}${
+          entry.label ? ` ${entry.label}` : ''
+        }`
+    )
+    .join(', ');
+
+export default function AdminDateViewSection() {
+  const [weekStart, setWeekStart] = useState(dayjs().startOf('week').format('YYYY-MM-DD'));
+  const summary = useQuery(api.availability.getAvailabilitySummaryRange, {
+    startDate: weekStart,
+    days: 7,
+  });
+
+  const employeeRows = useMemo(() => {
+    if (!summary) {
+      return [];
+    }
+
+    const rowMap = new Map<
+      string,
+      {
+        id: string;
+        label: string;
+        days: Array<{
+          date: string;
+          availabilityWindow: { start: string; end: string } | null;
+          appointmentCount: number;
+          breaks: Array<{ start: string; end: string; label?: string }>;
+          breakMode: 'add' | 'replace';
+          hasSchedule: boolean;
+        }>;
+      }
+    >();
+
+    summary.days.forEach((day) => {
+      day.employees.forEach((employee) => {
+        const current = rowMap.get(employee.id) ?? {
+          id: employee.id,
+          label: formatEmployeeName(employee),
+          days: [],
+        };
+        current.days.push({
+          date: day.date,
+          availabilityWindow: employee.availabilityWindow,
+          appointmentCount: employee.appointmentCount,
+          breaks: employee.breaks,
+          breakMode: employee.breakMode === 'replace' ? 'replace' : 'add',
+          hasSchedule: day.schedule != null,
+        });
+        rowMap.set(employee.id, current);
+      });
+    });
+
+    return Array.from(rowMap.values());
+  }, [summary]);
+
+  return (
+    <section className={styles.section}>
+      <div className={styles.sectionHeader}>
+        <div>
+          <h4>Availability calendar</h4>
+          <p className={styles.subtle}>Week view for staffing, appointments, and break coverage.</p>
+        </div>
+        <div className={styles.actions}>
+          <Button
+            variant="outlined"
+            onClick={() => setWeekStart(dayjs(weekStart).subtract(7, 'day').format('YYYY-MM-DD'))}
+          >
+            Previous week
+          </Button>
+          <Button
+            variant="outlined"
+            onClick={() => setWeekStart(dayjs(weekStart).add(7, 'day').format('YYYY-MM-DD'))}
+          >
+            Next week
+          </Button>
+        </div>
+      </div>
+
+      {!summary ? (
+        <p className={styles.subtle}>Loading calendar...</p>
+      ) : (
+        <div className={styles.calendar}>
+          <div className={`${styles.calendarCell} ${styles.calendarCorner}`}>Employee</div>
+          {summary.days.map((day) => (
+            <div key={day.date} className={`${styles.calendarCell} ${styles.calendarHeader}`}>
+              <strong>{dayjs(day.date).format('ddd')}</strong>
+              <span>{dayjs(day.date).format('MMM D')}</span>
+              {day.schedule ? (
+                <span className={styles.subtle}>
+                  {formatDateToTime(day.schedule.open)}-{formatDateToTime(day.schedule.close)}
+                </span>
+              ) : (
+                <span className={styles.subtle}>No shop schedule</span>
+              )}
+            </div>
+          ))}
+
+          {employeeRows.map((row) => (
+            <Fragment key={row.id}>
+              <div key={`${row.id}-label`} className={`${styles.calendarCell} ${styles.calendarRowLabel}`}>
+                {row.label}
+              </div>
+              {row.days.map((day) => (
+                <div
+                  key={`${row.id}-${day.date}`}
+                  className={`${styles.calendarCell} ${styles.calendarBodyCell}`}
+                >
+                  {!day.hasSchedule ? (
+                    <div className={styles.subtle}>No shop schedule</div>
+                  ) : !day.availabilityWindow ? (
+                    <div className={styles.subtle}>Off</div>
+                  ) : (
+                    <>
+                      <div>
+                        {formatDateToTime(day.availabilityWindow.start)}-
+                        {formatDateToTime(day.availabilityWindow.end)}
+                      </div>
+                      <div className={styles.subtle}>Booked: {day.appointmentCount}</div>
+                      {day.breaks.length > 0 ? (
+                        <div className={styles.subtle}>
+                          {day.breakMode === 'replace' ? 'Break plan:' : 'Extra breaks:'}{' '}
+                          {formatCellBreaks(day.breaks)}
+                        </div>
+                      ) : (
+                        <div className={styles.subtle}>No breaks</div>
+                      )}
+                    </>
+                  )}
+                </div>
+              ))}
+            </Fragment>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/client/src/routes/EmployeeAvailability/AvailabilityHeroCard.tsx
+++ b/client/src/routes/EmployeeAvailability/AvailabilityHeroCard.tsx
@@ -1,0 +1,23 @@
+import styles from './styles.module.css';
+import { formatEmployeeName } from './shared';
+
+export default function AvailabilityHeroCard({
+  employee,
+  defaultHours,
+}: {
+  employee: { firstName: string; lastName?: string };
+  defaultHours: { startTime: string; endTime: string };
+}) {
+  return (
+    <section className={styles.heroCard}>
+      <div>
+        <p className={styles.kicker}>Editing</p>
+        <h4 className={styles.heroTitle}>{formatEmployeeName(employee)}</h4>
+      </div>
+      <div className={styles.heroMeta}>
+        <span>Shop default start: {defaultHours.startTime}</span>
+        <span>Shop default end: {defaultHours.endTime}</span>
+      </div>
+    </section>
+  );
+}

--- a/client/src/routes/EmployeeAvailability/DateBreaksSection.tsx
+++ b/client/src/routes/EmployeeAvailability/DateBreaksSection.tsx
@@ -1,0 +1,207 @@
+import { useEffect, useState } from 'react';
+import Button from '@mui/material/Button';
+import MenuItem from '@mui/material/MenuItem';
+import TextField from '@mui/material/TextField';
+
+import { useMutation } from '@/convex/client';
+import { useNotification } from '@/hooks/useNotification';
+
+import styles from './styles.module.css';
+import { api } from '../../../../convex/_generated/api';
+
+type DateBreakDraft = {
+  id?: string;
+  date: string;
+  startTime: string;
+  endTime: string;
+  label?: string;
+  mode: 'add' | 'replace';
+};
+
+const createInitialDraft = (): DateBreakDraft => ({
+  date: new Date().toISOString().slice(0, 10),
+  startTime: '12:00',
+  endTime: '12:30',
+  label: '',
+  mode: 'add',
+});
+
+export default function DateBreaksSection({
+  dateBreaks,
+  dateBreakPolicies,
+  employeeId,
+}: {
+  dateBreaks: Array<{
+    id: string;
+    date: string;
+    startTime: string;
+    endTime: string;
+    label?: string;
+  }>;
+  dateBreakPolicies: Array<{
+    date: string;
+    mode: 'add' | 'replace';
+  }>;
+  employeeId?: string;
+}) {
+  const { handleSuccess, handleError } = useNotification();
+  const upsertAvailabilityDateBreak = useMutation(api.availability.upsertAvailabilityDateBreak);
+  const deleteAvailabilityDateBreak = useMutation(api.availability.deleteAvailabilityDateBreak);
+  const [draft, setDraft] = useState<DateBreakDraft>(createInitialDraft());
+
+  useEffect(() => {
+    setDraft(createInitialDraft());
+  }, [dateBreakPolicies, dateBreaks]);
+
+  const resetDraft = () => {
+    setDraft(createInitialDraft());
+  };
+
+  const handleSave = async () => {
+    try {
+      await upsertAvailabilityDateBreak({
+        ...(employeeId ? { employeeId } : {}),
+        dateBreak: {
+          id: draft.id,
+          date: draft.date,
+          startTime: draft.startTime,
+          endTime: draft.endTime,
+          label: draft.label,
+        },
+        mode: draft.mode,
+      });
+      handleSuccess('Date block saved');
+      resetDraft();
+    } catch (error) {
+      handleError(error);
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    try {
+      await deleteAvailabilityDateBreak({
+        ...(employeeId ? { employeeId } : {}),
+        id,
+      });
+      handleSuccess('Date block removed');
+      if (draft.id === id) {
+        resetDraft();
+      }
+    } catch (error) {
+      handleError(error);
+    }
+  };
+
+  return (
+    <section className={styles.section}>
+      <div className={styles.sectionHeader}>
+        <div>
+          <h4>Date-specific blocks</h4>
+          <p className={styles.subtle}>
+            Add one-off blocked time for appointments, errands, or custom lunch changes.
+          </p>
+        </div>
+        <div className={styles.actions}>
+          {draft.id && (
+            <Button variant="outlined" onClick={resetDraft}>
+              Cancel edit
+            </Button>
+          )}
+          <Button variant="contained" onClick={handleSave}>
+            {draft.id ? 'Update block' : 'Save block'}
+          </Button>
+        </div>
+      </div>
+
+      <div className={styles.overrideEditor}>
+        <TextField
+          label="Date"
+          type="date"
+          value={draft.date}
+          onChange={(event) =>
+            setDraft((current) => ({ ...current, date: event.target.value }))
+          }
+          InputLabelProps={{ shrink: true }}
+        />
+        <TextField
+          select
+          label="Date mode"
+          value={draft.mode}
+          onChange={(event) =>
+            setDraft((current) => ({
+              ...current,
+              mode: event.target.value as 'add' | 'replace',
+            }))
+          }
+        >
+          <MenuItem value="add">Add to recurring breaks</MenuItem>
+          <MenuItem value="replace">Replace recurring breaks</MenuItem>
+        </TextField>
+        <TextField
+          label="Start"
+          type="time"
+          value={draft.startTime}
+          onChange={(event) =>
+            setDraft((current) => ({ ...current, startTime: event.target.value }))
+          }
+          InputLabelProps={{ shrink: true }}
+        />
+        <TextField
+          label="End"
+          type="time"
+          value={draft.endTime}
+          onChange={(event) =>
+            setDraft((current) => ({ ...current, endTime: event.target.value }))
+          }
+          InputLabelProps={{ shrink: true }}
+        />
+        <TextField
+          label="Label"
+          value={draft.label ?? ''}
+          onChange={(event) =>
+            setDraft((current) => ({ ...current, label: event.target.value }))
+          }
+        />
+      </div>
+
+      <div className={styles.overrideList}>
+        {dateBreaks.length === 0 ? (
+          <p className={styles.subtle}>No date-specific blocks saved.</p>
+        ) : (
+          dateBreaks.map((entry) => (
+            <div key={entry.id} className={styles.overrideItem}>
+              <div>
+                <strong>{entry.date}</strong>
+                <div className={styles.subtle}>
+                  {entry.startTime} - {entry.endTime}
+                  {entry.label ? ` • ${entry.label}` : ''}
+                  {` • ${
+                    dateBreakPolicies.find((policy) => policy.date === entry.date)?.mode ===
+                    'replace'
+                      ? 'replaces recurring breaks'
+                      : 'adds to recurring breaks'
+                  }`}
+                </div>
+              </div>
+              <div className={styles.actions}>
+                <Button
+                  onClick={() =>
+                    setDraft({
+                      ...entry,
+                      mode:
+                        dateBreakPolicies.find((policy) => policy.date === entry.date)?.mode ??
+                        'add',
+                    })
+                  }
+                >
+                  Edit
+                </Button>
+                <Button onClick={() => handleDelete(entry.id)}>Delete</Button>
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+    </section>
+  );
+}

--- a/client/src/routes/EmployeeAvailability/DateOverridesSection.tsx
+++ b/client/src/routes/EmployeeAvailability/DateOverridesSection.tsx
@@ -1,0 +1,121 @@
+import Button from '@mui/material/Button';
+import TextField from '@mui/material/TextField';
+
+import type { EmployeeAvailabilityOverride } from '@/types';
+
+import styles from './styles.module.css';
+
+export default function DateOverridesSection({
+  overrideDraft,
+  overrides,
+  defaultHours,
+  editingOverrideDate,
+  onDraftChange,
+  onSave,
+  onCancelEdit,
+  onEdit,
+  onDelete,
+}: {
+  overrideDraft: Omit<EmployeeAvailabilityOverride, 'id'>;
+  overrides: EmployeeAvailabilityOverride[];
+  defaultHours: { startTime: string; endTime: string };
+  editingOverrideDate: string | null;
+  onDraftChange: (next: Omit<EmployeeAvailabilityOverride, 'id'>) => void;
+  onSave: () => void;
+  onCancelEdit: () => void;
+  onEdit: (override: EmployeeAvailabilityOverride) => void;
+  onDelete: (date: string) => void;
+}) {
+  return (
+    <section className={styles.section}>
+      <div className={styles.sectionHeader}>
+        <div>
+          <h4>Date overrides</h4>
+          <p className={styles.subtle}>Use this for days off or one-off shift changes.</p>
+        </div>
+        <div className={styles.actions}>
+          {editingOverrideDate && (
+            <Button variant="outlined" onClick={onCancelEdit}>
+              Cancel edit
+            </Button>
+          )}
+          <Button variant="contained" onClick={onSave}>
+            {editingOverrideDate ? 'Update override' : 'Save override'}
+          </Button>
+        </div>
+      </div>
+
+      <div className={styles.overrideEditor}>
+        <TextField
+          label="Date"
+          type="date"
+          value={overrideDraft.date}
+          onChange={(event) => onDraftChange({ ...overrideDraft, date: event.target.value })}
+          InputLabelProps={{ shrink: true }}
+        />
+        <label className={styles.checkbox}>
+          <input
+            type="checkbox"
+            checked={overrideDraft.isWorking}
+            onChange={(event) =>
+              onDraftChange({ ...overrideDraft, isWorking: event.target.checked })
+            }
+          />
+          Working that day
+        </label>
+        <TextField
+          label="Start"
+          type="time"
+          value={overrideDraft.startTime ?? defaultHours.startTime}
+          onChange={(event) =>
+            onDraftChange({ ...overrideDraft, startTime: event.target.value })
+          }
+          disabled={!overrideDraft.isWorking}
+          InputLabelProps={{ shrink: true }}
+        />
+        <TextField
+          label="End"
+          type="time"
+          value={overrideDraft.endTime ?? defaultHours.endTime}
+          onChange={(event) => onDraftChange({ ...overrideDraft, endTime: event.target.value })}
+          disabled={!overrideDraft.isWorking}
+          InputLabelProps={{ shrink: true }}
+        />
+        <TextField
+          label="Reason"
+          value={overrideDraft.reason ?? ''}
+          onChange={(event) => onDraftChange({ ...overrideDraft, reason: event.target.value })}
+        />
+      </div>
+
+      <div className={styles.overrideList}>
+        {overrides.length === 0 ? (
+          <p className={styles.subtle}>No overrides saved.</p>
+        ) : (
+          overrides.map((override) => (
+            <div
+              key={override.id}
+              className={`${styles.overrideItem} ${
+                editingOverrideDate === override.date ? styles.overrideItemActive : ''
+              }`}
+            >
+              <div>
+                <strong>{override.date}</strong>
+                <div className={styles.subtle}>
+                  {override.isWorking
+                    ? `${override.startTime} - ${override.endTime}`
+                    : 'Not working'}
+                  {override.reason ? ` • ${override.reason}` : ''}
+                </div>
+              </div>
+              <div className={styles.actions}>
+                <Button onClick={() => onEdit(override)}>Edit</Button>
+                <Button onClick={() => onDelete(override.date)}>Delete</Button>
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+    </section>
+  );
+}

--- a/client/src/routes/EmployeeAvailability/RecurringBreaksSection.tsx
+++ b/client/src/routes/EmployeeAvailability/RecurringBreaksSection.tsx
@@ -1,0 +1,191 @@
+import { useEffect, useState } from 'react';
+import Button from '@mui/material/Button';
+import MenuItem from '@mui/material/MenuItem';
+import TextField from '@mui/material/TextField';
+
+import { useMutation } from '@/convex/client';
+import { useNotification } from '@/hooks/useNotification';
+import type { Weekday } from '@/types';
+import { api } from '../../../../convex/_generated/api';
+
+import styles from './styles.module.css';
+
+const weekdayLabels = [
+  'Sunday',
+  'Monday',
+  'Tuesday',
+  'Wednesday',
+  'Thursday',
+  'Friday',
+  'Saturday',
+];
+
+type BreakDraft = {
+  id?: string;
+  weekday: Weekday;
+  startTime: string;
+  endTime: string;
+  label?: string;
+};
+
+const createInitialBreakDraft = (): BreakDraft => ({
+  weekday: 1,
+  startTime: '12:00',
+  endTime: '12:30',
+  label: '',
+});
+
+export default function RecurringBreaksSection({
+  breaks,
+  employeeId,
+}: {
+  breaks: Array<{
+    id: string;
+    weekday: number;
+    startTime: string;
+    endTime: string;
+    label?: string;
+  }>;
+  employeeId?: string;
+}) {
+  const { handleSuccess, handleError } = useNotification();
+  const upsertAvailabilityBreak = useMutation(api.availability.upsertAvailabilityBreak);
+  const deleteAvailabilityBreak = useMutation(api.availability.deleteAvailabilityBreak);
+  const [draft, setDraft] = useState<BreakDraft>(createInitialBreakDraft());
+
+  useEffect(() => {
+    setDraft(createInitialBreakDraft());
+  }, [breaks]);
+
+  const resetDraft = () => {
+    setDraft(createInitialBreakDraft());
+  };
+
+  const handleSave = async () => {
+    try {
+      await upsertAvailabilityBreak({
+        ...(employeeId ? { employeeId } : {}),
+        break: draft,
+      });
+      handleSuccess('Recurring break saved');
+      resetDraft();
+    } catch (error) {
+      handleError(error);
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    try {
+      await deleteAvailabilityBreak({
+        ...(employeeId ? { employeeId } : {}),
+        id,
+      });
+      handleSuccess('Recurring break removed');
+      if (draft.id === id) {
+        resetDraft();
+      }
+    } catch (error) {
+      handleError(error);
+    }
+  };
+
+  return (
+    <section className={styles.section}>
+      <div className={styles.sectionHeader}>
+        <div>
+          <h4>Recurring breaks</h4>
+          <p className={styles.subtle}>Lunch, cleanup, or any blocked time inside a shift.</p>
+        </div>
+        <div className={styles.actions}>
+          {draft.id && (
+            <Button variant="outlined" onClick={resetDraft}>
+              Cancel edit
+            </Button>
+          )}
+          <Button variant="contained" onClick={handleSave}>
+            {draft.id ? 'Update break' : 'Save break'}
+          </Button>
+        </div>
+      </div>
+
+      <div className={styles.overrideEditor}>
+        <TextField
+          select
+          label="Weekday"
+          value={draft.weekday}
+          onChange={(event) =>
+            setDraft((current) => ({
+              ...current,
+              weekday: Number(event.target.value) as Weekday,
+            }))
+          }
+        >
+          {weekdayLabels.map((label, weekday) => (
+            <MenuItem key={label} value={weekday}>
+              {label}
+            </MenuItem>
+          ))}
+        </TextField>
+        <TextField
+          label="Start"
+          type="time"
+          value={draft.startTime}
+          onChange={(event) =>
+            setDraft((current) => ({ ...current, startTime: event.target.value }))
+          }
+          InputLabelProps={{ shrink: true }}
+        />
+        <TextField
+          label="End"
+          type="time"
+          value={draft.endTime}
+          onChange={(event) =>
+            setDraft((current) => ({ ...current, endTime: event.target.value }))
+          }
+          InputLabelProps={{ shrink: true }}
+        />
+        <TextField
+          label="Label"
+          value={draft.label ?? ''}
+          onChange={(event) =>
+            setDraft((current) => ({ ...current, label: event.target.value }))
+          }
+        />
+      </div>
+
+      <div className={styles.overrideList}>
+        {breaks.length === 0 ? (
+          <p className={styles.subtle}>No recurring breaks saved.</p>
+        ) : (
+          breaks.map((entry) => (
+            <div key={entry.id} className={styles.overrideItem}>
+              <div>
+                <strong>{weekdayLabels[entry.weekday]}</strong>
+                <div className={styles.subtle}>
+                  {entry.startTime} - {entry.endTime}
+                  {entry.label ? ` • ${entry.label}` : ''}
+                </div>
+              </div>
+              <div className={styles.actions}>
+                <Button
+                  onClick={() =>
+                    setDraft({
+                      id: entry.id,
+                      weekday: entry.weekday as Weekday,
+                      startTime: entry.startTime,
+                      endTime: entry.endTime,
+                      label: entry.label,
+                    })
+                  }
+                >
+                  Edit
+                </Button>
+                <Button onClick={() => handleDelete(entry.id)}>Delete</Button>
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+    </section>
+  );
+}

--- a/client/src/routes/EmployeeAvailability/WeeklyScheduleSection.tsx
+++ b/client/src/routes/EmployeeAvailability/WeeklyScheduleSection.tsx
@@ -1,0 +1,86 @@
+import Button from '@mui/material/Button';
+import TextField from '@mui/material/TextField';
+
+import type { EmployeeAvailabilityWeeklyEntry } from '@/types';
+
+import styles from './styles.module.css';
+import { weekdayLabels } from './shared';
+
+export default function WeeklyScheduleSection({
+  weeklyDraft,
+  defaultHours,
+  onReset,
+  onSave,
+  onChange,
+  showEmptyHint,
+}: {
+  weeklyDraft: EmployeeAvailabilityWeeklyEntry[];
+  defaultHours: { startTime: string; endTime: string };
+  onReset: () => void;
+  onSave: () => void;
+  onChange: (
+    weekday: number,
+    field: keyof EmployeeAvailabilityWeeklyEntry,
+    value: boolean | string
+  ) => void;
+  showEmptyHint: boolean;
+}) {
+  return (
+    <section className={styles.section}>
+      <div className={styles.sectionHeader}>
+        <div>
+          <h4>Weekly schedule</h4>
+          {showEmptyHint && (
+            <p className={styles.subtle}>
+              No custom hours saved yet. Booking currently falls back to shop hours.
+            </p>
+          )}
+        </div>
+        <div className={styles.actions}>
+          <Button variant="outlined" onClick={onReset}>
+            Reset to shop hours
+          </Button>
+          <Button variant="contained" onClick={onSave}>
+            Save weekly hours
+          </Button>
+        </div>
+      </div>
+
+      <div className={styles.grid}>
+        {weeklyDraft.map((entry) => (
+          <div key={entry.weekday} className={styles.card}>
+            <div className={styles.dayRow}>
+              <strong>{weekdayLabels[entry.weekday]}</strong>
+              <label className={styles.checkbox}>
+                <input
+                  type="checkbox"
+                  checked={entry.isWorking}
+                  onChange={(event) => onChange(entry.weekday, 'isWorking', event.target.checked)}
+                />
+                Working
+              </label>
+            </div>
+            <div className={styles.timeRow}>
+              <TextField
+                label="Start"
+                type="time"
+                value={entry.startTime ?? defaultHours.startTime}
+                onChange={(event) => onChange(entry.weekday, 'startTime', event.target.value)}
+                disabled={!entry.isWorking}
+                InputLabelProps={{ shrink: true }}
+              />
+              <TextField
+                label="End"
+                type="time"
+                value={entry.endTime ?? defaultHours.endTime}
+                onChange={(event) => onChange(entry.weekday, 'endTime', event.target.value)}
+                disabled={!entry.isWorking}
+                InputLabelProps={{ shrink: true }}
+              />
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/client/src/routes/EmployeeAvailability/index.test.tsx
+++ b/client/src/routes/EmployeeAvailability/index.test.tsx
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, screen } from '@testing-library/react';
+
+import { render } from '@/test/test-utils';
+import EmployeeAvailability from './index';
+
+const mockAuthState = {
+  role: 'admin' as string | null,
+};
+
+const mockEmployees = [
+  {
+    id: 'employee-1',
+    firstName: 'Pat',
+    lastName: 'Barber',
+  },
+];
+
+const mockAvailabilityData = {
+  employee: {
+    id: 'employee-1',
+    firstName: 'Pat',
+    lastName: 'Barber',
+  },
+  defaultHours: {
+    startTime: '09:00',
+    endTime: '17:00',
+  },
+  weekly: [],
+  breaks: [],
+  dateBreaks: [],
+  dateBreakPolicies: [],
+  overrides: [
+    {
+      id: 'override-1',
+      date: '2026-02-09',
+      isWorking: false,
+      reason: 'Vacation',
+    },
+  ],
+};
+
+vi.mock('./AdminDateViewSection', () => ({
+  default: () => <div>Admin date view</div>,
+}));
+
+vi.mock('./RecurringBreaksSection', () => ({
+  default: () => <div>Recurring breaks</div>,
+}));
+
+vi.mock('./DateBreaksSection', () => ({
+  default: () => <div>Date-specific blocks</div>,
+}));
+
+const mutationMock = vi.fn().mockResolvedValue({ success: true });
+
+vi.mock('@/hooks/useAuth', () => ({
+  useAuth: () => mockAuthState,
+}));
+
+vi.mock('@/hooks/useEmployeesQuery', () => ({
+  useEmployeesQuery: () => ({
+    employees: mockEmployees,
+    isLoading: false,
+  }),
+}));
+
+vi.mock('@/hooks/useNotification', () => ({
+  useNotification: () => ({
+    handleSuccess: vi.fn(),
+    handleError: vi.fn(),
+  }),
+}));
+
+vi.mock('@/convex/client', () => ({
+  useQuery: () => mockAvailabilityData,
+  useMutation: () => mutationMock,
+}));
+
+describe('EmployeeAvailability', () => {
+  beforeEach(() => {
+    mockAuthState.role = 'admin';
+    mutationMock.mockClear();
+  });
+
+  it('shows the selected employee full name and lets overrides enter edit mode', () => {
+    render(<EmployeeAvailability />);
+
+    expect(screen.getAllByText('Pat Barber')).toHaveLength(2);
+    fireEvent.click(screen.getByRole('button', { name: /edit/i }));
+
+    expect(screen.getByDisplayValue('2026-02-09')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /update override/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /cancel edit/i })).toBeInTheDocument();
+    expect(screen.getByDisplayValue('Vacation')).toBeInTheDocument();
+  });
+
+  it('blocks non-employee, non-admin users', () => {
+    mockAuthState.role = 'client';
+
+    render(<EmployeeAvailability />);
+
+    expect(screen.getByText(/not allowed/i)).toBeInTheDocument();
+  });
+});

--- a/client/src/routes/EmployeeAvailability/index.tsx
+++ b/client/src/routes/EmployeeAvailability/index.tsx
@@ -1,0 +1,249 @@
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router';
+import MenuItem from '@mui/material/MenuItem';
+import TextField from '@mui/material/TextField';
+
+import { useMutation, useQuery } from '@/convex/client';
+import { useAuth } from '@/hooks/useAuth';
+import { useEmployeesQuery } from '@/hooks/useEmployeesQuery';
+import { useNotification } from '@/hooks/useNotification';
+import AccessDenied from '@/routes/RequireAuth/AccessDenied';
+import type { EmployeeAvailabilityOverride, EmployeeAvailabilityWeeklyEntry } from '@/types';
+import { api } from '../../../../convex/_generated/api';
+import AdminDateViewSection from './AdminDateViewSection';
+import AvailabilityHeroCard from './AvailabilityHeroCard';
+import DateOverridesSection from './DateOverridesSection';
+import DateBreaksSection from './DateBreaksSection';
+import RecurringBreaksSection from './RecurringBreaksSection';
+import WeeklyScheduleSection from './WeeklyScheduleSection';
+import {
+  buildOverrideDraft,
+  buildWeeklyDraft,
+  cloneOverrideDraft,
+  createEmptyWeeklyDraft,
+  formatEmployeeName,
+} from './shared';
+
+import styles from './styles.module.css';
+
+export default function EmployeeAvailability() {
+  const { role } = useAuth();
+  const isAdmin = role === 'admin';
+  const isEmployee = role === 'employee';
+  const { employees } = useEmployeesQuery();
+  const { handleSuccess, handleError } = useNotification();
+  const [selectedEmployeeId, setSelectedEmployeeId] = useState('');
+  const [weeklyDraft, setWeeklyDraft] = useState<EmployeeAvailabilityWeeklyEntry[]>([]);
+  const [overrideDraft, setOverrideDraft] = useState<
+    Omit<EmployeeAvailabilityOverride, 'id'>
+  >({
+    date: new Date().toISOString().slice(0, 10),
+    isWorking: false,
+    startTime: '09:00',
+    endTime: '17:00',
+    reason: '',
+  });
+  const [editingOverrideDate, setEditingOverrideDate] = useState<string | null>(null);
+
+  const availabilityData = useQuery(
+    api.availability.getAvailability,
+    isAdmin ? (selectedEmployeeId ? { employeeId: selectedEmployeeId } : 'skip') : {}
+  );
+
+  const saveWeeklyAvailability = useMutation(api.availability.saveWeeklyAvailability);
+  const upsertAvailabilityOverride = useMutation(
+    api.availability.upsertAvailabilityOverride
+  );
+  const deleteAvailabilityOverride = useMutation(
+    api.availability.deleteAvailabilityOverride
+  );
+
+  useEffect(() => {
+    if (!isAdmin || selectedEmployeeId || employees.length === 0) {
+      return;
+    }
+    setSelectedEmployeeId(employees[0].id);
+  }, [employees, isAdmin, selectedEmployeeId]);
+
+  useEffect(() => {
+    if (!availabilityData) {
+      return;
+    }
+    setWeeklyDraft(buildWeeklyDraft(availabilityData));
+    setOverrideDraft(buildOverrideDraft(availabilityData));
+    setEditingOverrideDate(null);
+  }, [availabilityData]);
+
+  if (!isAdmin && !isEmployee) {
+    return <AccessDenied requiredRole="employee" />;
+  }
+
+  if (isAdmin && employees.length === 0) {
+    return (
+      <main className="container-lg">
+        <div className="mt-4">
+          <Link to="/account">Back to account page</Link>
+        </div>
+        <h3 className={styles.header}>Availability</h3>
+        <p>No employees found.</p>
+      </main>
+    );
+  }
+
+  const handleWeeklyChange = (
+    weekday: number,
+    field: keyof EmployeeAvailabilityWeeklyEntry,
+    value: boolean | string
+  ) => {
+    setWeeklyDraft((current) =>
+      current.map((entry) =>
+        entry.weekday === weekday ? { ...entry, [field]: value } : entry
+      )
+    );
+  };
+
+  const handleSaveWeekly = async () => {
+    try {
+      await saveWeeklyAvailability({
+        ...(isAdmin ? { employeeId: selectedEmployeeId } : {}),
+        weekly: weeklyDraft,
+      });
+      handleSuccess('Availability updated');
+    } catch (error) {
+      handleError(error);
+    }
+  };
+
+  const handleResetWeekly = () => {
+    if (!availabilityData) {
+      return;
+    }
+    setWeeklyDraft(createEmptyWeeklyDraft(availabilityData.defaultHours));
+  };
+
+  const resetOverrideDraft = () => {
+    if (!availabilityData) {
+      return;
+    }
+    setOverrideDraft(buildOverrideDraft(availabilityData));
+    setEditingOverrideDate(null);
+  };
+
+  const handleSaveOverride = async () => {
+    try {
+      await upsertAvailabilityOverride({
+        ...(isAdmin ? { employeeId: selectedEmployeeId } : {}),
+        override: overrideDraft,
+      });
+      handleSuccess('Availability override saved');
+      resetOverrideDraft();
+    } catch (error) {
+      handleError(error);
+    }
+  };
+
+  const handleDeleteOverride = async (date: string) => {
+    try {
+      await deleteAvailabilityOverride({
+        ...(isAdmin ? { employeeId: selectedEmployeeId } : {}),
+        date,
+      });
+      handleSuccess('Availability override removed');
+      if (editingOverrideDate === date) {
+        resetOverrideDraft();
+      }
+    } catch (error) {
+      handleError(error);
+    }
+  };
+
+  const handleEditOverride = (override: EmployeeAvailabilityOverride) => {
+    setOverrideDraft(
+      cloneOverrideDraft({
+        date: override.date,
+        isWorking: override.isWorking,
+        startTime: override.startTime,
+        endTime: override.endTime,
+        reason: override.reason ?? '',
+      })
+    );
+    setEditingOverrideDate(override.date);
+  };
+
+  return (
+    <main className={`container-lg ${styles.page}`}>
+      <div className="mt-4">
+        <Link to="/account">Back to account page</Link>
+      </div>
+      <h3 className={styles.header}>Manage availability</h3>
+      <p className={styles.subtle}>
+        Weekly hours define the default. Date overrides handle vacation, time off, or
+        special shifts.
+      </p>
+
+      {isAdmin && (
+        <TextField
+          select
+          label="Employee"
+          value={selectedEmployeeId}
+          onChange={(event) => setSelectedEmployeeId(event.target.value)}
+          className={styles.employeeSelect}
+        >
+          {employees.map((employee) => (
+            <MenuItem key={employee.id} value={employee.id}>
+              {formatEmployeeName(employee)}
+            </MenuItem>
+          ))}
+        </TextField>
+      )}
+
+      {!availabilityData ? (
+        <p>Loading availability...</p>
+      ) : (
+        <>
+          <AvailabilityHeroCard
+            employee={availabilityData.employee}
+            defaultHours={availabilityData.defaultHours}
+          />
+
+          <RecurringBreaksSection
+            breaks={availabilityData.breaks}
+            employeeId={isAdmin ? selectedEmployeeId : undefined}
+          />
+
+          <DateBreaksSection
+            dateBreaks={availabilityData.dateBreaks}
+            dateBreakPolicies={availabilityData.dateBreakPolicies.map((policy) => ({
+              date: policy.date,
+              mode: policy.mode === 'replace' ? 'replace' : 'add',
+            }))}
+            employeeId={isAdmin ? selectedEmployeeId : undefined}
+          />
+
+          <WeeklyScheduleSection
+            weeklyDraft={weeklyDraft}
+            defaultHours={availabilityData.defaultHours}
+            onReset={handleResetWeekly}
+            onSave={handleSaveWeekly}
+            onChange={handleWeeklyChange}
+            showEmptyHint={availabilityData.weekly.length === 0}
+          />
+
+          <DateOverridesSection
+            overrideDraft={overrideDraft}
+            overrides={availabilityData.overrides}
+            defaultHours={availabilityData.defaultHours}
+            editingOverrideDate={editingOverrideDate}
+            onDraftChange={setOverrideDraft}
+            onSave={handleSaveOverride}
+            onCancelEdit={resetOverrideDraft}
+            onEdit={handleEditOverride}
+            onDelete={handleDeleteOverride}
+          />
+
+          {isAdmin && <AdminDateViewSection />}
+        </>
+      )}
+    </main>
+  );
+}

--- a/client/src/routes/EmployeeAvailability/shared.ts
+++ b/client/src/routes/EmployeeAvailability/shared.ts
@@ -1,0 +1,78 @@
+import type {
+  EmployeeAvailabilityOverride,
+  EmployeeAvailabilityWeeklyEntry,
+  Weekday,
+} from '@/types';
+
+export const weekdayLabels = [
+  'Sunday',
+  'Monday',
+  'Tuesday',
+  'Wednesday',
+  'Thursday',
+  'Friday',
+  'Saturday',
+] as const;
+
+export const formatEmployeeName = (employee: {
+  firstName: string;
+  lastName?: string;
+}) => [employee.firstName, employee.lastName].filter(Boolean).join(' ');
+
+export const createEmptyWeeklyDraft = (defaultHours: {
+  startTime: string;
+  endTime: string;
+}): EmployeeAvailabilityWeeklyEntry[] =>
+  weekdayLabels.map((_, weekday) => ({
+    weekday: weekday as Weekday,
+    isWorking: true,
+    startTime: defaultHours.startTime,
+    endTime: defaultHours.endTime,
+  }));
+
+export const buildWeeklyDraft = (data: {
+  defaultHours: {
+    startTime: string;
+    endTime: string;
+  };
+  weekly: Array<{
+    weekday: number;
+    isWorking: boolean;
+    startTime?: string;
+    endTime?: string;
+  }>;
+}): EmployeeAvailabilityWeeklyEntry[] => {
+  const byWeekday = new Map(data.weekly.map((entry) => [entry.weekday, entry]));
+  return weekdayLabels.map((_, weekday) => {
+    const existing = byWeekday.get(weekday as Weekday);
+    return {
+      weekday: weekday as Weekday,
+      isWorking: existing?.isWorking ?? true,
+      startTime: existing?.startTime ?? data.defaultHours.startTime,
+      endTime: existing?.endTime ?? data.defaultHours.endTime,
+    };
+  });
+};
+
+export const buildOverrideDraft = (data: {
+  defaultHours: {
+    startTime: string;
+    endTime: string;
+  };
+}): Omit<EmployeeAvailabilityOverride, 'id'> => ({
+  date: new Date().toISOString().slice(0, 10),
+  isWorking: false,
+  startTime: data.defaultHours.startTime,
+  endTime: data.defaultHours.endTime,
+  reason: '',
+});
+
+export const cloneOverrideDraft = (
+  override: Omit<EmployeeAvailabilityOverride, 'id'>
+): Omit<EmployeeAvailabilityOverride, 'id'> => ({
+  date: override.date,
+  isWorking: override.isWorking,
+  startTime: override.startTime,
+  endTime: override.endTime,
+  reason: override.reason ?? '',
+});

--- a/client/src/routes/EmployeeAvailability/styles.module.css
+++ b/client/src/routes/EmployeeAvailability/styles.module.css
@@ -1,0 +1,190 @@
+.page {
+  display: grid;
+  gap: 1.5rem;
+  padding-block: 1.5rem 3rem;
+}
+
+.header {
+  margin: 0;
+}
+
+.subtle {
+  margin: 0;
+  color: rgba(0, 0, 0, 0.68);
+}
+
+.employeeSelect {
+  max-width: 18rem;
+}
+
+.heroCard {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.25rem;
+  border-radius: 1rem;
+  color: #f8f3e8;
+  background:
+    radial-gradient(circle at top left, rgba(255, 212, 110, 0.25), transparent 35%),
+    linear-gradient(135deg, #1e2b24 0%, #364737 100%);
+}
+
+.kicker {
+  margin: 0 0 0.25rem;
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.72;
+}
+
+.heroTitle {
+  margin: 0;
+}
+
+.heroMeta {
+  display: grid;
+  gap: 0.4rem;
+  justify-items: end;
+  font-size: 0.95rem;
+}
+
+.section {
+  display: grid;
+  gap: 1rem;
+  padding: 1.25rem;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-radius: 1rem;
+  background: rgba(255, 255, 255, 0.92);
+}
+
+.sectionHeader {
+  display: flex;
+  gap: 1rem;
+  align-items: flex-start;
+  justify-content: space-between;
+}
+
+.actions {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+  justify-content: flex-end;
+}
+
+.grid {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.card {
+  display: grid;
+  gap: 0.75rem;
+  padding: 1rem;
+  border-radius: 0.875rem;
+  background: rgba(0, 0, 0, 0.03);
+}
+
+.dayRow {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.checkbox {
+  display: inline-flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.timeRow {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(2, minmax(0, 12rem));
+}
+
+.overrideEditor {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));
+}
+
+.overrideList {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.overrideItem {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.875rem 1rem;
+  border-radius: 0.875rem;
+  background: rgba(0, 0, 0, 0.03);
+}
+
+.overrideItemActive {
+  outline: 2px solid rgba(53, 92, 72, 0.38);
+  background: rgba(53, 92, 72, 0.08);
+}
+
+.calendar {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: minmax(10rem, 1.3fr) repeat(7, minmax(9rem, 1fr));
+  overflow-x: auto;
+}
+
+.calendarCell {
+  min-width: 0;
+  padding: 0.875rem;
+  border-radius: 0.875rem;
+  background: rgba(0, 0, 0, 0.03);
+}
+
+.calendarCorner,
+.calendarHeader,
+.calendarRowLabel {
+  font-weight: 600;
+}
+
+.calendarHeader {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.calendarRowLabel {
+  align-self: stretch;
+  display: flex;
+  align-items: center;
+}
+
+.calendarBodyCell {
+  display: grid;
+  gap: 0.4rem;
+}
+
+@media (max-width: 640px) {
+  .heroCard,
+  .sectionHeader,
+  .dayRow,
+  .overrideItem {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .heroMeta {
+    justify-items: start;
+  }
+
+  .timeRow {
+    grid-template-columns: 1fr;
+  }
+
+  .calendar {
+    grid-template-columns: minmax(9rem, 1.1fr) repeat(7, minmax(8.5rem, 1fr));
+  }
+}

--- a/client/src/routes/routes.test.tsx
+++ b/client/src/routes/routes.test.tsx
@@ -294,6 +294,22 @@ describe('Route Navigation', () => {
     expect(screen.getByRole('link', { name: /account/i })).toBeInTheDocument();
   });
 
+  it('Account page shows availability link for employees', () => {
+    mockAuthState.user = 'employee@example.com';
+    mockAuthState.role = 'employee';
+    const TestRoutes = () => (
+      <Routes>
+        <Route element={<RequireAuth />}>
+          <Route path="/account" element={<Account />} />
+        </Route>
+      </Routes>
+    );
+
+    render(<TestRoutes />, { route: '/account' });
+
+    expect(screen.getByRole('link', { name: /manage availability/i })).toBeInTheDocument();
+  });
+
   it('Account page hides appointments link for admin', () => {
     mockAuthState.user = 'admin@example.com';
     mockAuthState.role = 'admin';

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -14,9 +14,23 @@ export interface Slot {
   available: string[];
 }
 
+export interface EmployeeAvailabilityWindow {
+  employeeId: string;
+  start: string;
+  end: string;
+}
+
+export interface EmployeeBreakWindow extends EmployeeAvailabilityWindow {
+  id: string;
+  label?: string;
+}
+
+export type Weekday = 0 | 1 | 2 | 3 | 4 | 5 | 6;
+
 export interface User {
   id: string;
   firstName: string;
+  lastName?: string;
 }
 
 export interface Appointment {
@@ -38,6 +52,8 @@ export interface Schedule {
   date?: string;
   open: string;
   close: string;
+  employeeAvailability?: EmployeeAvailabilityWindow[];
+  employeeBreaks?: EmployeeBreakWindow[];
   appointments: Appointment[];
 }
 
@@ -56,15 +72,88 @@ export interface ScheduleSummary {
   appointmentStatusCounts: ScheduleAppointmentStatusCounts;
 }
 
+export interface EmployeeAvailabilityWeeklyEntry {
+  weekday: Weekday;
+  isWorking: boolean;
+  startTime?: string;
+  endTime?: string;
+}
+
+export interface EmployeeAvailabilityOverride {
+  id: string;
+  date: string;
+  isWorking: boolean;
+  startTime?: string;
+  endTime?: string;
+  reason?: string;
+}
+
+export interface EmployeeAvailabilityBreak {
+  id: string;
+  weekday: Weekday;
+  startTime: string;
+  endTime: string;
+  label?: string;
+}
+
+export interface EmployeeAvailabilityDateBreak {
+  id: string;
+  date: string;
+  startTime: string;
+  endTime: string;
+  label?: string;
+}
+
+export interface EmployeeAvailabilityDateBreakPolicy {
+  date: string;
+  mode: 'add' | 'replace';
+}
+
+export interface EmployeeAvailabilityResponse {
+  employee: User & { lastName?: string };
+  defaultHours: {
+    startTime: string;
+    endTime: string;
+  };
+  weekly: EmployeeAvailabilityWeeklyEntry[];
+  overrides: EmployeeAvailabilityOverride[];
+  breaks: EmployeeAvailabilityBreak[];
+  dateBreaks: EmployeeAvailabilityDateBreak[];
+  dateBreakPolicies: EmployeeAvailabilityDateBreakPolicy[];
+}
+
+export interface EmployeeAvailabilitySummaryItem {
+  id: string;
+  firstName: string;
+  lastName?: string;
+  availabilityWindow: EmployeeAvailabilityWindow | null;
+  breaks: EmployeeBreakWindow[];
+  breakMode: 'add' | 'replace';
+  appointmentCount: number;
+}
+
+export interface EmployeeAvailabilitySummaryResponse {
+  date: string;
+  schedule: {
+    id: string;
+    open: string;
+    close: string;
+  } | null;
+  employees: EmployeeAvailabilitySummaryItem[];
+}
+
+export interface EmployeeAvailabilitySummaryRangeResponse {
+  startDate: string;
+  endDate: string;
+  days: EmployeeAvailabilitySummaryResponse[];
+}
+
 export interface RouteError {
   statusText?: string;
   message?: string;
 }
 
-export interface Employee {
-  id: string;
-  firstName: string;
-}
+export type Employee = User;
 
 export interface EmployeeProfile {
   id: string;

--- a/client/src/utils/date.test.ts
+++ b/client/src/utils/date.test.ts
@@ -138,4 +138,69 @@ describe('date normalization helpers', () => {
 
     expect(formatTime(slots[0].start)).toBe('8:00am');
   });
+
+  it('filters time slots by employee availability windows', () => {
+    vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+
+    const slots = findAvailableTimeSlots(
+      {
+        open: '2099-01-24T14:00:00.000Z',
+        close: '2099-01-24T18:00:00.000Z',
+        employeeAvailability: [
+          {
+            employeeId: 'emp-1',
+            start: '2099-01-24T15:00:00.000Z',
+            end: '2099-01-24T17:00:00.000Z',
+          },
+        ],
+        appointments: [],
+      },
+      30,
+      ['emp-1'],
+      undefined
+    );
+
+    expect(slots).toHaveLength(7);
+    expect(slots[0].start.toISOString()).toBe('2099-01-24T15:00:00.000Z');
+    expect(slots[slots.length - 1]?.start.toISOString()).toBe(
+      '2099-01-24T16:30:00.000Z'
+    );
+  });
+
+  it('filters time slots that overlap employee breaks', () => {
+    vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+
+    const slots = findAvailableTimeSlots(
+      {
+        open: '2099-01-24T14:00:00.000Z',
+        close: '2099-01-24T18:00:00.000Z',
+        employeeAvailability: [
+          {
+            employeeId: 'emp-1',
+            start: '2099-01-24T14:00:00.000Z',
+            end: '2099-01-24T18:00:00.000Z',
+          },
+        ],
+        employeeBreaks: [
+          {
+            id: 'break-1',
+            employeeId: 'emp-1',
+            start: '2099-01-24T15:00:00.000Z',
+            end: '2099-01-24T15:30:00.000Z',
+          },
+        ],
+        appointments: [],
+      },
+      30,
+      ['emp-1'],
+      undefined
+    );
+
+    expect(
+      slots.some((slot) => slot.start.toISOString() === '2099-01-24T15:00:00.000Z')
+    ).toBe(false);
+    expect(
+      slots.some((slot) => slot.start.toISOString() === '2099-01-24T15:15:00.000Z')
+    ).toBe(false);
+  });
 });

--- a/client/src/utils/date.ts
+++ b/client/src/utils/date.ts
@@ -102,6 +102,17 @@ interface ScheduleAppointment {
 interface ScheduleInput {
   open: string;
   close: string;
+  employeeAvailability?: {
+    employeeId: string;
+    start: string;
+    end: string;
+  }[];
+  employeeBreaks?: {
+    id: string;
+    employeeId: string;
+    start: string;
+    end: string;
+  }[];
   appointments: ScheduleAppointment[];
 }
 
@@ -138,15 +149,55 @@ export const findAvailableTimeSlots = (
     }
 
     const selectedEmployees = employee ? [employee.id] : employees;
+    const employeeAvailability = new Map(
+      (schedule.employeeAvailability ?? []).map((window) => [window.employeeId, window])
+    );
+    const employeeBreaks = (schedule.employeeBreaks ?? []).reduce<
+      Map<string, { id: string; start: string; end: string }[]>
+    >((acc, entry) => {
+      const current = acc.get(entry.employeeId) ?? [];
+      current.push(entry);
+      acc.set(entry.employeeId, current);
+      return acc;
+    }, new Map());
+    const hasAvailabilityWindows = employeeAvailability.size > 0;
     const availableEmployees = selectedEmployees.filter((employeeId) => {
+      const normalizedEmployeeId = String(employeeId);
+      const availabilityWindow = employeeAvailability.get(normalizedEmployeeId);
+      const isWithinAvailability = hasAvailabilityWindows
+        ? Boolean(
+            availabilityWindow &&
+              !toBusinessDateTime(availabilityWindow.start).isAfter(slotStart) &&
+              !toBusinessDateTime(availabilityWindow.end).isBefore(currentSlotEnd)
+          )
+        : true;
+      if (!isWithinAvailability) {
+        return false;
+      }
+
+      const hasBreakConflict = (employeeBreaks.get(normalizedEmployeeId) ?? []).some(
+        (entry) =>
+          toBusinessDateTime(entry.start).isBefore(currentSlotEnd) &&
+          toBusinessDateTime(entry.end).isAfter(slotStart)
+      );
+      if (hasBreakConflict) {
+        return false;
+      }
+
       const employeeAppointments = appointments.filter((appointment) => {
-        const apptEmpId = appointment.employeeId ||
-          (appointment.employee && typeof appointment.employee === 'object' ? appointment.employee.id : appointment.employee);
-        return apptEmpId === employeeId;
+        const apptEmpId =
+          appointment.employeeId ||
+          (appointment.employee && typeof appointment.employee === 'object'
+            ? appointment.employee.id
+            : appointment.employee);
+        return apptEmpId === normalizedEmployeeId;
       });
       const employeeBooked = employeeAppointments.some(
-        (appointment) => toBusinessDateTime(appointment.start).isBefore(currentSlotEnd) &&
-        (appointment.end ? toBusinessDateTime(appointment.end).isAfter(slotStart) : false)
+        (appointment) =>
+          toBusinessDateTime(appointment.start).isBefore(currentSlotEnd) &&
+          (appointment.end
+            ? toBusinessDateTime(appointment.end).isAfter(slotStart)
+            : false)
       );
       return !employeeBooked;
     });

--- a/convex-tests/src/availability.test.ts
+++ b/convex-tests/src/availability.test.ts
@@ -1,0 +1,497 @@
+import { describe, expect, it } from 'vitest';
+
+import { api, components } from '../../convex/_generated/api';
+import { createConvexTest } from './convexTest';
+
+const scheduleDate = '2026-02-02';
+const scheduleId = 'schedule-1';
+
+const createAuthUser = async (
+  t: ReturnType<typeof createConvexTest>,
+  role: 'admin' | 'client' | 'employee'
+) => {
+  const now = Date.now();
+  const name = `${role[0].toUpperCase()}${role.slice(1)} User`;
+  const email = `${role}@example.com`;
+
+  const authUser = await t.mutation(components.betterAuth.adapter.create, {
+    input: {
+      model: 'user',
+      data: {
+        name,
+        email,
+        emailVerified: false,
+        createdAt: now,
+        updatedAt: now,
+      },
+    },
+  });
+
+  const authUserId =
+    (authUser as { id?: string; _id?: string }).id ??
+    (authUser as { _id?: string })._id;
+  if (!authUserId) {
+    throw new Error('Auth user id missing from better-auth adapter response.');
+  }
+
+  const session = await t.mutation(components.betterAuth.adapter.create, {
+    input: {
+      model: 'session',
+      data: {
+        userId: authUserId,
+        token: `session-${authUserId}`,
+        createdAt: now,
+        updatedAt: now,
+        expiresAt: now + 60 * 60 * 1000,
+      },
+    },
+  });
+
+  const sessionId =
+    (session as { id?: string; _id?: string }).id ??
+    (session as { _id?: string })._id;
+  if (!sessionId) {
+    throw new Error('Session id missing from better-auth adapter response.');
+  }
+
+  await t.run(async (ctx) => {
+    await ctx.db.insert('users', {
+      id: authUserId,
+      name,
+      firstName: role === 'employee' ? 'Pat' : role === 'admin' ? 'Alex' : 'Casey',
+      lastName: 'User',
+      email,
+      role,
+      createdAt: now,
+      updatedAt: now,
+    });
+  });
+
+  return {
+    id: authUserId,
+    identity: {
+      subject: authUserId,
+      sessionId,
+      name,
+      email,
+    },
+  };
+};
+
+const seedSchedule = async (t: ReturnType<typeof createConvexTest>) => {
+  await t.run(async (ctx) => {
+    await ctx.db.insert('schedules', {
+      id: scheduleId,
+      date: scheduleDate,
+      open: '2026-02-02T15:00:00.000Z',
+      close: '2026-02-02T21:00:00.000Z',
+    });
+  });
+};
+
+describe('employee availability', () => {
+  it('allows employees to save and query weekly availability', async () => {
+    const t = createConvexTest();
+    const employee = await createAuthUser(t, 'employee');
+
+    const asEmployee = t.withIdentity(employee.identity);
+    await asEmployee.mutation(api.availability.saveWeeklyAvailability, {
+      weekly: [
+        { weekday: 0, isWorking: false },
+        { weekday: 1, isWorking: true, startTime: '11:00', endTime: '15:00' },
+        { weekday: 2, isWorking: true, startTime: '09:00', endTime: '17:00' },
+        { weekday: 3, isWorking: true, startTime: '09:00', endTime: '17:00' },
+        { weekday: 4, isWorking: true, startTime: '09:00', endTime: '17:00' },
+        { weekday: 5, isWorking: true, startTime: '09:00', endTime: '17:00' },
+        { weekday: 6, isWorking: false },
+      ],
+    });
+    await asEmployee.mutation(api.availability.upsertAvailabilityBreak, {
+      break: {
+        weekday: 1,
+        startTime: '12:00',
+        endTime: '12:30',
+        label: 'Lunch',
+      },
+    });
+    await asEmployee.mutation(api.availability.upsertAvailabilityDateBreak, {
+      dateBreak: {
+        date: '2026-02-03',
+        startTime: '14:00',
+        endTime: '14:30',
+        label: 'Dentist',
+      },
+      mode: 'replace',
+    });
+
+    const availability = await asEmployee.query(api.availability.getAvailability, {});
+
+    expect(availability.weekly).toEqual(
+      expect.arrayContaining([
+        {
+          weekday: 1,
+          isWorking: true,
+          startTime: '11:00',
+          endTime: '15:00',
+        },
+        {
+          weekday: 6,
+          isWorking: false,
+          startTime: undefined,
+          endTime: undefined,
+        },
+      ])
+    );
+    expect(availability.breaks).toEqual([
+      {
+        id: expect.any(String),
+        weekday: 1,
+        startTime: '12:00',
+        endTime: '12:30',
+        label: 'Lunch',
+      },
+    ]);
+    expect(availability.dateBreaks).toEqual([
+      {
+        id: expect.any(String),
+        date: '2026-02-03',
+        startTime: '14:00',
+        endTime: '14:30',
+        label: 'Dentist',
+      },
+    ]);
+    expect(availability.dateBreakPolicies).toEqual([
+      {
+        date: '2026-02-03',
+        mode: 'replace',
+      },
+    ]);
+  });
+
+  it('returns employee availability windows on public schedules', async () => {
+    const t = createConvexTest();
+    const employee = await createAuthUser(t, 'employee');
+    await seedSchedule(t);
+
+    await t.run(async (ctx) => {
+      await ctx.db.insert('employeeAvailabilityRules', {
+        id: 'rule-1',
+        employeeId: employee.id,
+        weekday: 1,
+        isWorking: true,
+        startTime: '11:00',
+        endTime: '14:00',
+        updatedAt: Date.now(),
+      });
+      await ctx.db.insert('employeeAvailabilityBreaks', {
+        id: 'break-1',
+        employeeId: employee.id,
+        weekday: 1,
+        startTime: '12:00',
+        endTime: '12:30',
+        label: 'Lunch',
+        updatedAt: Date.now(),
+      });
+      await ctx.db.insert('employeeAvailabilityDateBreaks', {
+        id: 'date-break-1',
+        employeeId: employee.id,
+        date: scheduleDate,
+        startTime: '13:30',
+        endTime: '14:00',
+        label: 'Supply run',
+        updatedAt: Date.now(),
+      });
+      await ctx.db.insert('employeeAvailabilityDateBreakPolicies', {
+        id: 'date-break-policy-1',
+        employeeId: employee.id,
+        date: scheduleDate,
+        mode: 'replace',
+        updatedAt: Date.now(),
+      });
+    });
+
+    const schedule = await t.query(api.schedules.getPublicScheduleByDate, {
+      date: scheduleDate,
+    });
+
+    expect(schedule?.employeeAvailability).toEqual([
+      {
+        employeeId: employee.id,
+        start: '2026-02-02T16:00:00.000Z',
+        end: '2026-02-02T19:00:00.000Z',
+      },
+    ]);
+    expect(schedule?.employeeBreaks).toEqual([
+      {
+        id: 'date-break-1',
+        employeeId: employee.id,
+        start: '2026-02-02T18:30:00.000Z',
+        end: '2026-02-02T19:00:00.000Z',
+        label: 'Supply run',
+      },
+    ]);
+  });
+
+  it('still allows booking when no availability rules exist', async () => {
+    const t = createConvexTest();
+    const employee = await createAuthUser(t, 'employee');
+    const client = await createAuthUser(t, 'client');
+    await seedSchedule(t);
+
+    const asClient = t.withIdentity(client.identity);
+    await expect(
+      asClient.mutation(api.appointments.createAppointment, {
+        start: '2026-02-02T16:00:00.000Z',
+        end: '2026-02-02T16:30:00.000Z',
+        service: 'Haircut',
+        employee: { id: employee.id, firstName: 'Pat' },
+      })
+    ).resolves.toMatchObject({
+      success: true,
+    });
+  });
+
+  it('rejects bookings outside an explicit availability window', async () => {
+    const t = createConvexTest();
+    const employee = await createAuthUser(t, 'employee');
+    const client = await createAuthUser(t, 'client');
+    await seedSchedule(t);
+
+    await t.run(async (ctx) => {
+      await ctx.db.insert('employeeAvailabilityRules', {
+        id: 'rule-outside-window-1',
+        employeeId: employee.id,
+        weekday: 1,
+        isWorking: true,
+        startTime: '11:00',
+        endTime: '14:00',
+        updatedAt: Date.now(),
+      });
+    });
+
+    const asClient = t.withIdentity(client.identity);
+    await expect(
+      asClient.mutation(api.appointments.createAppointment, {
+        start: '2026-02-02T20:00:00.000Z',
+        end: '2026-02-02T20:30:00.000Z',
+        service: 'Haircut',
+        employee: { id: employee.id, firstName: 'Pat' },
+      })
+    ).rejects.toThrow(/Employee is unavailable for selected time/);
+  });
+
+  it('rejects bookings that overlap a date-specific break', async () => {
+    const t = createConvexTest();
+    const employee = await createAuthUser(t, 'employee');
+    const client = await createAuthUser(t, 'client');
+    await seedSchedule(t);
+
+    await t.run(async (ctx) => {
+      await ctx.db.insert('employeeAvailabilityRules', {
+        id: 'rule-2',
+        employeeId: employee.id,
+        weekday: 1,
+        isWorking: true,
+        startTime: '11:00',
+        endTime: '15:00',
+        updatedAt: Date.now(),
+      });
+      await ctx.db.insert('employeeAvailabilityBreaks', {
+        id: 'break-2',
+        employeeId: employee.id,
+        weekday: 1,
+        startTime: '12:00',
+        endTime: '12:30',
+        label: 'Lunch',
+        updatedAt: Date.now(),
+      });
+      await ctx.db.insert('employeeAvailabilityDateBreaks', {
+        id: 'date-break-2',
+        employeeId: employee.id,
+        date: scheduleDate,
+        startTime: '14:00',
+        endTime: '14:30',
+        label: 'Errand',
+        updatedAt: Date.now(),
+      });
+      await ctx.db.insert('employeeAvailabilityDateBreakPolicies', {
+        id: 'date-break-policy-2',
+        employeeId: employee.id,
+        date: scheduleDate,
+        mode: 'replace',
+        updatedAt: Date.now(),
+      });
+    });
+
+    const asClient = t.withIdentity(client.identity);
+    await expect(
+      asClient.mutation(api.appointments.createAppointment, {
+        start: '2026-02-02T19:00:00.000Z',
+        end: '2026-02-02T19:30:00.000Z',
+        service: 'Haircut',
+        employee: { id: employee.id, firstName: 'Pat' },
+      })
+    ).rejects.toThrow(/Employee is unavailable for selected time/);
+  });
+
+  it('allows bookings during recurring break when date policy replaces it', async () => {
+    const t = createConvexTest();
+    const employee = await createAuthUser(t, 'employee');
+    const client = await createAuthUser(t, 'client');
+    await seedSchedule(t);
+
+    await t.run(async (ctx) => {
+      await ctx.db.insert('employeeAvailabilityRules', {
+        id: 'rule-3',
+        employeeId: employee.id,
+        weekday: 1,
+        isWorking: true,
+        startTime: '11:00',
+        endTime: '15:00',
+        updatedAt: Date.now(),
+      });
+      await ctx.db.insert('employeeAvailabilityBreaks', {
+        id: 'break-allow-1',
+        employeeId: employee.id,
+        weekday: 1,
+        startTime: '12:00',
+        endTime: '12:30',
+        label: 'Lunch',
+        updatedAt: Date.now(),
+      });
+      await ctx.db.insert('employeeAvailabilityDateBreaks', {
+        id: 'date-break-allow-1',
+        employeeId: employee.id,
+        date: scheduleDate,
+        startTime: '14:00',
+        endTime: '14:30',
+        label: 'Errand',
+        updatedAt: Date.now(),
+      });
+      await ctx.db.insert('employeeAvailabilityDateBreakPolicies', {
+        id: 'date-break-policy-allow-1',
+        employeeId: employee.id,
+        date: scheduleDate,
+        mode: 'replace',
+        updatedAt: Date.now(),
+      });
+    });
+
+    const asClient = t.withIdentity(client.identity);
+    await expect(
+      asClient.mutation(api.appointments.createAppointment, {
+        start: '2026-02-02T17:00:00.000Z',
+        end: '2026-02-02T17:30:00.000Z',
+        service: 'Haircut',
+        employee: { id: employee.id, firstName: 'Pat' },
+      })
+    ).resolves.toMatchObject({
+      success: true,
+    });
+  });
+
+  it('returns an admin date summary with breaks and appointment counts', async () => {
+    const t = createConvexTest();
+    const employee = await createAuthUser(t, 'employee');
+    const admin = await createAuthUser(t, 'admin');
+    await seedSchedule(t);
+
+    await t.run(async (ctx) => {
+      await ctx.db.insert('employeeAvailabilityBreaks', {
+        id: 'break-3',
+        employeeId: employee.id,
+        weekday: 1,
+        startTime: '12:00',
+        endTime: '12:30',
+        label: 'Lunch',
+        updatedAt: Date.now(),
+      });
+      await ctx.db.insert('employeeAvailabilityDateBreaks', {
+        id: 'date-break-3',
+        employeeId: employee.id,
+        date: scheduleDate,
+        startTime: '14:00',
+        endTime: '14:30',
+        label: 'School pickup',
+        updatedAt: Date.now(),
+      });
+      await ctx.db.insert('employeeAvailabilityDateBreakPolicies', {
+        id: 'date-break-policy-3',
+        employeeId: employee.id,
+        date: scheduleDate,
+        mode: 'replace',
+        updatedAt: Date.now(),
+      });
+      await ctx.db.insert('appointments', {
+        id: 'appointment-1',
+        status: 'scheduled',
+        service: 'Haircut',
+        start: '2026-02-02T16:00:00.000Z',
+        end: '2026-02-02T16:30:00.000Z',
+        clientId: 'client-1',
+        employeeId: employee.id,
+        scheduleId,
+      });
+    });
+
+    const asAdmin = t.withIdentity(admin.identity);
+    const summary = await asAdmin.query(api.availability.getAvailabilitySummaryByDate, {
+      date: scheduleDate,
+    });
+
+    expect(summary.schedule).toMatchObject({
+      id: scheduleId,
+    });
+    expect(summary.employees).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: employee.id,
+          appointmentCount: 1,
+          breakMode: 'replace',
+          breaks: [
+            expect.objectContaining({
+              id: 'date-break-3',
+              label: 'School pickup',
+            }),
+          ],
+        }),
+      ])
+    );
+  });
+
+  it('returns a range summary for calendar view', async () => {
+    const t = createConvexTest();
+    const employee = await createAuthUser(t, 'employee');
+    const admin = await createAuthUser(t, 'admin');
+    await seedSchedule(t);
+
+    await t.run(async (ctx) => {
+      await ctx.db.insert('employeeAvailabilityDateBreaks', {
+        id: 'date-break-range-1',
+        employeeId: employee.id,
+        date: scheduleDate,
+        startTime: '14:00',
+        endTime: '14:30',
+        label: 'Errand',
+        updatedAt: Date.now(),
+      });
+    });
+
+    const asAdmin = t.withIdentity(admin.identity);
+    const summary = await asAdmin.query(api.availability.getAvailabilitySummaryRange, {
+      startDate: scheduleDate,
+      days: 2,
+    });
+
+    expect(summary.startDate).toBe(scheduleDate);
+    expect(summary.days).toHaveLength(2);
+    expect(summary.days[0]).toMatchObject({
+      date: scheduleDate,
+      schedule: { id: scheduleId },
+    });
+    expect(summary.days[1]).toMatchObject({
+      date: '2026-02-03',
+      schedule: null,
+    });
+  });
+});

--- a/convex-tests/src/availability.test.ts
+++ b/convex-tests/src/availability.test.ts
@@ -89,7 +89,7 @@ const seedSchedule = async (t: ReturnType<typeof createConvexTest>) => {
   });
 };
 
-describe('employee availability', () => {
+describe('employee availability', { timeout: 15000 }, () => {
   it('allows employees to save and query weekly availability', async () => {
     const t = createConvexTest();
     const employee = await createAuthUser(t, 'employee');

--- a/convex-tests/src/schedules.test.ts
+++ b/convex-tests/src/schedules.test.ts
@@ -186,6 +186,48 @@ describe('schedules queries', () => {
     });
   });
 
+  it('keeps cancelled appointments in private schedules but excludes them from public booking data', async () => {
+    const t = createConvexTest();
+    await seedSchedules(t);
+    await seedUsersAndAppointment(t);
+    const admin = await createAuthUser(t, 'admin');
+
+    await t.run(async (ctx) => {
+      await ctx.db.insert('appointments', {
+        id: 'appointment-cancelled',
+        status: 'cancelled',
+        service: 'Haircut',
+        start: '2026-02-02T17:00:00.000Z',
+        end: '2026-02-02T17:30:00.000Z',
+        clientId,
+        employeeId,
+        scheduleId,
+      });
+    });
+
+    const publicSchedule = await t.query(api.schedules.getPublicScheduleByDate, {
+      date: scheduleDate,
+    });
+
+    expect(publicSchedule?.appointments.map((appointment) => appointment.id)).toEqual([
+      'appointment-1',
+    ]);
+
+    const asAdmin = t.withIdentity(admin.identity);
+    const privateSchedule = await asAdmin.query(api.schedules.getPrivateScheduleById, {
+      id: scheduleId,
+    });
+
+    expect(privateSchedule?.appointments.map((appointment) => appointment.id)).toEqual([
+      'appointment-1',
+      'appointment-cancelled',
+    ]);
+    expect(privateSchedule?.appointments.find((appointment) => appointment.id === 'appointment-cancelled'))
+      .toMatchObject({
+        status: 'cancelled',
+      });
+  });
+
   it('lists private schedules by view with compact dashboard summaries', async () => {
     const t = createConvexTest();
     await seedSchedules(t);

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -10,6 +10,7 @@
 
 import type * as appointments from "../appointments.js";
 import type * as auth from "../auth.js";
+import type * as availability from "../availability.js";
 import type * as crons from "../crons.js";
 import type * as email from "../email.js";
 import type * as emailOutbox from "../emailOutbox.js";
@@ -21,6 +22,9 @@ import type * as lib_appointmentAccess from "../lib/appointmentAccess.js";
 import type * as lib_appointments from "../lib/appointments.js";
 import type * as lib_auth from "../lib/auth.js";
 import type * as lib_authUrls from "../lib/authUrls.js";
+import type * as lib_availability from "../lib/availability.js";
+import type * as lib_availabilityAccess from "../lib/availabilityAccess.js";
+import type * as lib_availabilitySummary from "../lib/availabilitySummary.js";
 import type * as lib_dateTime from "../lib/dateTime.js";
 import type * as lib_emailOutbox from "../lib/emailOutbox.js";
 import type * as lib_emailTemplates from "../lib/emailTemplates.js";
@@ -37,6 +41,7 @@ import type {
 declare const fullApi: ApiFromModules<{
   appointments: typeof appointments;
   auth: typeof auth;
+  availability: typeof availability;
   crons: typeof crons;
   email: typeof email;
   emailOutbox: typeof emailOutbox;
@@ -48,6 +53,9 @@ declare const fullApi: ApiFromModules<{
   "lib/appointments": typeof lib_appointments;
   "lib/auth": typeof lib_auth;
   "lib/authUrls": typeof lib_authUrls;
+  "lib/availability": typeof lib_availability;
+  "lib/availabilityAccess": typeof lib_availabilityAccess;
+  "lib/availabilitySummary": typeof lib_availabilitySummary;
   "lib/dateTime": typeof lib_dateTime;
   "lib/emailOutbox": typeof lib_emailOutbox;
   "lib/emailTemplates": typeof lib_emailTemplates;

--- a/convex/availability.ts
+++ b/convex/availability.ts
@@ -1,0 +1,465 @@
+import { ConvexError, v } from "convex/values";
+import dayjs from "dayjs";
+
+import { mutation, query } from "./_generated/server";
+import { requireAdmin } from "./lib/auth";
+import {
+  loadAvailabilityForDate,
+  loadAvailabilityForEmployee,
+  resolveBreakWindows,
+  resolveAvailabilityWindow,
+  validateAvailabilityInput,
+  validateBreakInput,
+} from "./lib/availability";
+import {
+  buildDefaultHours,
+  resolveAvailabilityActor,
+} from "./lib/availabilityAccess";
+import { buildAvailabilitySummaryForDate } from "./lib/availabilitySummary";
+
+const weekdayValidator = v.union(
+  v.literal(0),
+  v.literal(1),
+  v.literal(2),
+  v.literal(3),
+  v.literal(4),
+  v.literal(5),
+  v.literal(6)
+);
+
+const weeklyEntryValidator = v.object({
+  weekday: weekdayValidator,
+  isWorking: v.boolean(),
+  startTime: v.optional(v.string()),
+  endTime: v.optional(v.string()),
+});
+
+const overrideValidator = v.object({
+  date: v.string(),
+  isWorking: v.boolean(),
+  startTime: v.optional(v.string()),
+  endTime: v.optional(v.string()),
+  reason: v.optional(v.string()),
+});
+
+const breakValidator = v.object({
+  id: v.optional(v.string()),
+  weekday: weekdayValidator,
+  startTime: v.string(),
+  endTime: v.string(),
+  label: v.optional(v.string()),
+});
+
+const dateBreakValidator = v.object({
+  id: v.optional(v.string()),
+  date: v.string(),
+  startTime: v.string(),
+  endTime: v.string(),
+  label: v.optional(v.string()),
+});
+
+const dateBreakModeValidator = v.union(v.literal("add"), v.literal("replace"));
+
+export const getAvailability = query({
+  args: {
+    employeeId: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const { employee } = await resolveAvailabilityActor(ctx, args.employeeId);
+    const [{ rules, overrides, breaks, dateBreaks, dateBreakPolicies }, defaultHours] =
+      await Promise.all([
+      loadAvailabilityForEmployee(ctx, employee.id),
+      buildDefaultHours(ctx),
+      ]);
+
+    return {
+      employee: {
+        id: employee.id,
+        firstName: employee.firstName ?? "Employee",
+        lastName: employee.lastName ?? "",
+      },
+      defaultHours,
+      weekly: rules
+        .sort((a, b) => a.weekday - b.weekday)
+        .map((rule) => ({
+          weekday: rule.weekday,
+          isWorking: rule.isWorking,
+          startTime: rule.startTime,
+          endTime: rule.endTime,
+        })),
+      overrides: overrides
+        .sort((a, b) => a.date.localeCompare(b.date))
+        .map((override) => ({
+          id: override.id,
+          date: override.date,
+          isWorking: override.isWorking,
+          startTime: override.startTime,
+          endTime: override.endTime,
+          reason: override.reason,
+        })),
+      breaks: breaks
+        .sort((a, b) =>
+          a.weekday === b.weekday
+            ? a.startTime.localeCompare(b.startTime)
+            : a.weekday - b.weekday
+        )
+        .map((entry) => ({
+          id: entry.id,
+          weekday: entry.weekday,
+          startTime: entry.startTime,
+          endTime: entry.endTime,
+          label: entry.label,
+        })),
+      dateBreaks: dateBreaks
+        .sort((a, b) =>
+          a.date === b.date
+            ? a.startTime.localeCompare(b.startTime)
+            : a.date.localeCompare(b.date)
+        )
+        .map((entry) => ({
+          id: entry.id,
+          date: entry.date,
+          startTime: entry.startTime,
+          endTime: entry.endTime,
+          label: entry.label,
+        })),
+      dateBreakPolicies: dateBreakPolicies
+        .sort((a, b) => a.date.localeCompare(b.date))
+        .map((entry) => ({
+          date: entry.date,
+          mode: entry.mode === "replace" ? "replace" : "add",
+        })),
+    };
+  },
+});
+
+export const getAvailabilitySummaryByDate = query({
+  args: {
+    date: v.string(),
+  },
+  handler: async (ctx, args) => {
+    await requireAdmin(ctx);
+    return buildAvailabilitySummaryForDate(ctx, args.date);
+  },
+});
+
+export const getAvailabilitySummaryRange = query({
+  args: {
+    startDate: v.string(),
+    days: v.number(),
+  },
+  handler: async (ctx, args) => {
+    await requireAdmin(ctx);
+
+    if (args.days <= 0 || args.days > 14) {
+      throw new ConvexError("days must be between 1 and 14");
+    }
+
+    const dates = Array.from({ length: args.days }, (_, offset) =>
+      dayjs(args.startDate).add(offset, "day").format("YYYY-MM-DD")
+    );
+    const summaries = await Promise.all(
+      dates.map((date) => buildAvailabilitySummaryForDate(ctx, date))
+    );
+
+    return {
+      startDate: dates[0],
+      endDate: dates[dates.length - 1],
+      days: summaries,
+    };
+  },
+});
+
+export const saveWeeklyAvailability = mutation({
+  args: {
+    employeeId: v.optional(v.string()),
+    weekly: v.array(weeklyEntryValidator),
+  },
+  handler: async (ctx, args) => {
+    const { employee } = await resolveAvailabilityActor(ctx, args.employeeId);
+
+    if (args.weekly.length !== 7) {
+      throw new ConvexError("Weekly availability must include all 7 weekdays");
+    }
+
+    const weekdaySet = new Set<number>();
+    for (const entry of args.weekly) {
+      if (weekdaySet.has(entry.weekday)) {
+        throw new ConvexError("Duplicate weekday in availability payload");
+      }
+      weekdaySet.add(entry.weekday);
+      validateAvailabilityInput(entry);
+    }
+
+    const existing = await ctx.db
+      .query("employeeAvailabilityRules")
+      .withIndex("by_employee", (q) => q.eq("employeeId", employee.id))
+      .collect();
+    const byWeekday = new Map(existing.map((row) => [row.weekday, row]));
+    const now = Date.now();
+
+    await Promise.all(
+      args.weekly.map(async (entry) => {
+        const current = byWeekday.get(entry.weekday);
+        const nextDocument = {
+          id: current?.id ?? crypto.randomUUID(),
+          employeeId: employee.id,
+          weekday: entry.weekday,
+          isWorking: entry.isWorking,
+          ...(entry.isWorking ? { startTime: entry.startTime, endTime: entry.endTime } : {}),
+          updatedAt: now,
+        };
+
+        if (current) {
+          await ctx.db.replace(current._id, nextDocument);
+          return;
+        }
+
+        await ctx.db.insert("employeeAvailabilityRules", nextDocument);
+      })
+    );
+
+    return { success: true };
+  },
+});
+
+export const upsertAvailabilityBreak = mutation({
+  args: {
+    employeeId: v.optional(v.string()),
+    break: breakValidator,
+  },
+  handler: async (ctx, args) => {
+    const { employee } = await resolveAvailabilityActor(ctx, args.employeeId);
+    validateBreakInput(args.break);
+
+    const existing = args.break.id
+      ? await ctx.db
+          .query("employeeAvailabilityBreaks")
+          .withIndex("by_availability_break_id", (q) => q.eq("id", args.break.id!))
+          .first()
+      : null;
+
+    if (existing && existing.employeeId !== employee.id) {
+      throw new ConvexError("Forbidden");
+    }
+
+    const nextDocument = {
+      id: existing?.id ?? crypto.randomUUID(),
+      employeeId: employee.id,
+      weekday: args.break.weekday,
+      startTime: args.break.startTime,
+      endTime: args.break.endTime,
+      ...(args.break.label?.trim() ? { label: args.break.label.trim() } : {}),
+      updatedAt: Date.now(),
+    };
+
+    if (existing) {
+      await ctx.db.replace(existing._id, nextDocument);
+    } else {
+      await ctx.db.insert("employeeAvailabilityBreaks", nextDocument);
+    }
+
+    return { success: true };
+  },
+});
+
+export const deleteAvailabilityBreak = mutation({
+  args: {
+    employeeId: v.optional(v.string()),
+    id: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const { employee } = await resolveAvailabilityActor(ctx, args.employeeId);
+    const existing = await ctx.db
+      .query("employeeAvailabilityBreaks")
+      .withIndex("by_availability_break_id", (q) => q.eq("id", args.id))
+      .first();
+
+    if (!existing) {
+      return { success: true };
+    }
+
+    if (existing.employeeId !== employee.id) {
+      throw new ConvexError("Forbidden");
+    }
+
+    await ctx.db.delete(existing._id);
+    return { success: true };
+  },
+});
+
+export const upsertAvailabilityDateBreak = mutation({
+  args: {
+    employeeId: v.optional(v.string()),
+    dateBreak: dateBreakValidator,
+    mode: v.optional(dateBreakModeValidator),
+  },
+  handler: async (ctx, args) => {
+    const { employee } = await resolveAvailabilityActor(ctx, args.employeeId);
+    validateBreakInput(args.dateBreak);
+
+    const existing = args.dateBreak.id
+      ? await ctx.db
+          .query("employeeAvailabilityDateBreaks")
+          .withIndex("by_availability_date_break_id", (q) =>
+            q.eq("id", args.dateBreak.id!)
+          )
+          .first()
+      : null;
+
+    if (existing && existing.employeeId !== employee.id) {
+      throw new ConvexError("Forbidden");
+    }
+
+    const nextDocument = {
+      id: existing?.id ?? crypto.randomUUID(),
+      employeeId: employee.id,
+      date: args.dateBreak.date,
+      startTime: args.dateBreak.startTime,
+      endTime: args.dateBreak.endTime,
+      ...(args.dateBreak.label?.trim()
+        ? { label: args.dateBreak.label.trim() }
+        : {}),
+      updatedAt: Date.now(),
+    };
+
+    if (existing) {
+      await ctx.db.replace(existing._id, nextDocument);
+    } else {
+      await ctx.db.insert("employeeAvailabilityDateBreaks", nextDocument);
+    }
+
+    const existingPolicy = await ctx.db
+      .query("employeeAvailabilityDateBreakPolicies")
+      .withIndex("by_employee_date", (q) =>
+        q.eq("employeeId", employee.id).eq("date", args.dateBreak.date)
+      )
+      .first();
+    const nextMode = args.mode ?? "add";
+    const nextPolicy = {
+      id: existingPolicy?.id ?? crypto.randomUUID(),
+      employeeId: employee.id,
+      date: args.dateBreak.date,
+      mode: nextMode,
+      updatedAt: Date.now(),
+    };
+
+    if (existingPolicy) {
+      await ctx.db.replace(existingPolicy._id, nextPolicy);
+    } else {
+      await ctx.db.insert("employeeAvailabilityDateBreakPolicies", nextPolicy);
+    }
+
+    return { success: true };
+  },
+});
+
+export const deleteAvailabilityDateBreak = mutation({
+  args: {
+    employeeId: v.optional(v.string()),
+    id: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const { employee } = await resolveAvailabilityActor(ctx, args.employeeId);
+    const existing = await ctx.db
+      .query("employeeAvailabilityDateBreaks")
+      .withIndex("by_availability_date_break_id", (q) => q.eq("id", args.id))
+      .first();
+
+    if (!existing) {
+      return { success: true };
+    }
+
+    if (existing.employeeId !== employee.id) {
+      throw new ConvexError("Forbidden");
+    }
+
+    const deletedDate = existing.date;
+    await ctx.db.delete(existing._id);
+
+    const remainingBreaks = await ctx.db
+      .query("employeeAvailabilityDateBreaks")
+      .withIndex("by_employee_date", (q) =>
+        q.eq("employeeId", employee.id).eq("date", deletedDate)
+      )
+      .collect();
+    if (remainingBreaks.length === 0) {
+      const policy = await ctx.db
+        .query("employeeAvailabilityDateBreakPolicies")
+        .withIndex("by_employee_date", (q) =>
+          q.eq("employeeId", employee.id).eq("date", deletedDate)
+        )
+        .first();
+      if (policy) {
+        await ctx.db.delete(policy._id);
+      }
+    }
+    return { success: true };
+  },
+});
+
+export const upsertAvailabilityOverride = mutation({
+  args: {
+    employeeId: v.optional(v.string()),
+    override: overrideValidator,
+  },
+  handler: async (ctx, args) => {
+    const { employee } = await resolveAvailabilityActor(ctx, args.employeeId);
+    validateAvailabilityInput(args.override);
+
+    const existing = await ctx.db
+      .query("employeeAvailabilityOverrides")
+      .withIndex("by_employee_date", (q) =>
+        q.eq("employeeId", employee.id).eq("date", args.override.date)
+      )
+      .first();
+
+    const nextDocument = {
+      id: existing?.id ?? crypto.randomUUID(),
+      employeeId: employee.id,
+      date: args.override.date,
+      isWorking: args.override.isWorking,
+      ...(args.override.isWorking
+        ? {
+            startTime: args.override.startTime,
+            endTime: args.override.endTime,
+          }
+        : {}),
+      ...(args.override.reason?.trim()
+        ? { reason: args.override.reason.trim() }
+        : {}),
+      updatedAt: Date.now(),
+    };
+
+    if (existing) {
+      await ctx.db.replace(existing._id, nextDocument);
+    } else {
+      await ctx.db.insert("employeeAvailabilityOverrides", nextDocument);
+    }
+
+    return { success: true };
+  },
+});
+
+export const deleteAvailabilityOverride = mutation({
+  args: {
+    employeeId: v.optional(v.string()),
+    date: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const { employee } = await resolveAvailabilityActor(ctx, args.employeeId);
+    const existing = await ctx.db
+      .query("employeeAvailabilityOverrides")
+      .withIndex("by_employee_date", (q) =>
+        q.eq("employeeId", employee.id).eq("date", args.date)
+      )
+      .first();
+
+    if (!existing) {
+      return { success: true };
+    }
+
+    await ctx.db.delete(existing._id);
+    return { success: true };
+  },
+});

--- a/convex/employees.ts
+++ b/convex/employees.ts
@@ -2,9 +2,13 @@ import { query } from "./_generated/server";
 import type { Doc } from "./_generated/dataModel";
 import { parseName } from "./lib/names";
 
-const getFirstName = (user: Doc<"users">) => {
+const toPublicEmployee = (user: Doc<"users">) => {
   const parsed = parseName(user.name);
-  return user.firstName ?? parsed.firstName ?? "User";
+  return {
+    id: user.id,
+    firstName: user.firstName ?? parsed.firstName ?? "User",
+    lastName: user.lastName ?? parsed.lastName ?? "",
+  };
 };
 
 export const getEmployees = query({
@@ -15,10 +19,6 @@ export const getEmployees = query({
       .withIndex("by_role", (q) => q.eq("role", "employee"))
       .collect();
 
-    return employees.map((employee) => ({
-      id: employee.id,
-      firstName: getFirstName(employee),
-    }));
+    return employees.map(toPublicEmployee);
   },
 });
-

--- a/convex/lib/appointments.ts
+++ b/convex/lib/appointments.ts
@@ -5,6 +5,12 @@ import type { MutationCtx, QueryCtx } from "../_generated/server";
 import { revokeAppointmentAccessTokens } from "./appointmentAccess";
 import { checkAvailabilityISO, extractDateFromISO } from "./dateTime";
 import { enqueueAppointmentEmail } from "./emailOutbox";
+import {
+  isSlotWithinAvailability,
+  loadAvailabilityForDate,
+  resolveBreakWindows,
+  resolveAvailabilityWindow,
+} from "./availability";
 import { parseName } from "./names";
 
 type DbCtx = { db: QueryCtx["db"] };
@@ -78,6 +84,19 @@ export const findScheduleForDate = async (ctx: DbCtx, date: string) => {
   return schedule;
 };
 
+const findScheduleById = async (ctx: DbCtx, scheduleId: string) => {
+  const schedule = await ctx.db
+    .query("schedules")
+    .withIndex("by_schedule_id", (q) => q.eq("id", scheduleId))
+    .first();
+
+  if (!schedule) {
+    throw new ConvexError("No schedule found for selected date");
+  }
+
+  return schedule;
+};
+
 export const assertAvailable = async (
   ctx: DbCtx,
   scheduleId: string,
@@ -105,6 +124,26 @@ export const assertAvailable = async (
 
   if (!availability) {
     throw new ConvexError("Time slot conflicts with existing appointment");
+  }
+
+  const schedule = await findScheduleById(ctx, scheduleId);
+  const availabilityData = await loadAvailabilityForDate(ctx, schedule.date);
+  const employeeWindow = resolveAvailabilityWindow(
+    schedule,
+    candidate.employeeId,
+    availabilityData.rulesByEmployeeId,
+    availabilityData.overridesByEmployeeId
+  );
+  const breakWindows = resolveBreakWindows(
+    schedule,
+    candidate.employeeId,
+    availabilityData.breaksByEmployeeId,
+    availabilityData.dateBreaksByEmployeeId,
+    availabilityData.dateBreakPoliciesByEmployeeId
+  );
+
+  if (!isSlotWithinAvailability(employeeWindow, candidate, breakWindows)) {
+    throw new ConvexError("Employee is unavailable for selected time");
   }
 };
 

--- a/convex/lib/availability.ts
+++ b/convex/lib/availability.ts
@@ -1,0 +1,297 @@
+import dayjs from "dayjs";
+import timezone from "dayjs/plugin/timezone";
+import utc from "dayjs/plugin/utc";
+import { ConvexError } from "convex/values";
+
+import type { Doc } from "../_generated/dataModel";
+import type { QueryCtx } from "../_generated/server";
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
+
+const selectedTimeZone = "America/New_York";
+
+type DbCtx = { db: QueryCtx["db"] };
+type ScheduleDoc = Doc<"schedules">;
+type WeeklyRuleDoc = Doc<"employeeAvailabilityRules">;
+type OverrideDoc = Doc<"employeeAvailabilityOverrides">;
+type BreakDoc = Doc<"employeeAvailabilityBreaks">;
+type DateBreakDoc = Doc<"employeeAvailabilityDateBreaks">;
+type DateBreakPolicyDoc = Doc<"employeeAvailabilityDateBreakPolicies">;
+
+export type AvailabilityWindow = {
+  employeeId: string;
+  start: string;
+  end: string;
+};
+
+export type BreakWindow = AvailabilityWindow & {
+  id: string;
+  label?: string;
+};
+
+type RuleInput = {
+  isWorking: boolean;
+  startTime?: string;
+  endTime?: string;
+};
+
+const timePattern = /^([01]\d|2[0-3]):([0-5]\d)$/;
+
+const parseTimeString = (value: string) => {
+  const match = timePattern.exec(value);
+  if (!match) {
+    throw new ConvexError(`Invalid time value: ${value}`);
+  }
+  return {
+    hour: Number(match[1]),
+    minute: Number(match[2]),
+  };
+};
+
+const combineDateAndTime = (date: string, time: string) => {
+  const { hour, minute } = parseTimeString(time);
+  return dayjs
+    .tz(date, selectedTimeZone)
+    .hour(hour)
+    .minute(minute)
+    .second(0)
+    .millisecond(0);
+};
+
+const normalizeWindow = (
+  schedule: ScheduleDoc,
+  startTime?: string,
+  endTime?: string
+) => {
+  if (!startTime || !endTime) {
+    return {
+      start: schedule.open,
+      end: schedule.close,
+    };
+  }
+
+  const rangeStart = combineDateAndTime(schedule.date, startTime);
+  const rangeEnd = combineDateAndTime(schedule.date, endTime);
+  const scheduleStart = dayjs.utc(schedule.open);
+  const scheduleEnd = dayjs.utc(schedule.close);
+
+  const start = rangeStart.isAfter(scheduleStart) ? rangeStart : scheduleStart;
+  const end = rangeEnd.isBefore(scheduleEnd) ? rangeEnd : scheduleEnd;
+
+  if (!start.isBefore(end)) {
+    return null;
+  }
+
+  return {
+    start: start.toISOString(),
+    end: end.toISOString(),
+  };
+};
+
+const overlaps = (
+  left: { start: string; end: string },
+  right: { start: string; end: string }
+) => left.start < right.end && left.end > right.start;
+
+export const validateAvailabilityInput = ({
+  isWorking,
+  startTime,
+  endTime,
+}: RuleInput) => {
+  if (!isWorking) {
+    return;
+  }
+
+  if (!startTime || !endTime) {
+    throw new ConvexError("Working availability requires start and end times");
+  }
+
+  const start = combineDateAndTime("2026-01-01", startTime);
+  const end = combineDateAndTime("2026-01-01", endTime);
+  if (!start.isBefore(end)) {
+    throw new ConvexError("Availability end time must be after start time");
+  }
+};
+
+export const validateBreakInput = ({
+  startTime,
+  endTime,
+}: {
+  startTime: string;
+  endTime: string;
+}) => {
+  const start = combineDateAndTime("2026-01-01", startTime);
+  const end = combineDateAndTime("2026-01-01", endTime);
+  if (!start.isBefore(end)) {
+    throw new ConvexError("Break end time must be after start time");
+  }
+};
+
+export const loadAvailabilityForDate = async (ctx: DbCtx, date: string) => {
+  const weekday = dayjs.tz(date, selectedTimeZone).day();
+  const [rules, overrides, breaks, dateBreaks, dateBreakPolicies] = await Promise.all([
+    ctx.db
+      .query("employeeAvailabilityRules")
+      .withIndex("by_weekday", (q) => q.eq("weekday", weekday))
+      .collect(),
+    ctx.db
+      .query("employeeAvailabilityOverrides")
+      .withIndex("by_date", (q) => q.eq("date", date))
+      .collect(),
+    ctx.db
+      .query("employeeAvailabilityBreaks")
+      .withIndex("by_weekday", (q) => q.eq("weekday", weekday))
+      .collect(),
+    ctx.db
+      .query("employeeAvailabilityDateBreaks")
+      .withIndex("by_date", (q) => q.eq("date", date))
+      .collect(),
+    ctx.db
+      .query("employeeAvailabilityDateBreakPolicies")
+      .withIndex("by_date", (q) => q.eq("date", date))
+      .collect(),
+  ]);
+
+  return {
+    rulesByEmployeeId: new Map(rules.map((rule) => [rule.employeeId, rule])),
+    overridesByEmployeeId: new Map(
+      overrides.map((override) => [override.employeeId, override])
+    ),
+    breaksByEmployeeId: breaks.reduce<Map<string, BreakDoc[]>>((acc, entry) => {
+      const current = acc.get(entry.employeeId) ?? [];
+      current.push(entry);
+      acc.set(entry.employeeId, current);
+      return acc;
+    }, new Map()),
+    dateBreaksByEmployeeId: dateBreaks.reduce<Map<string, DateBreakDoc[]>>(
+      (acc, entry) => {
+        const current = acc.get(entry.employeeId) ?? [];
+        current.push(entry);
+        acc.set(entry.employeeId, current);
+        return acc;
+      },
+      new Map()
+    ),
+    dateBreakPoliciesByEmployeeId: new Map(
+      dateBreakPolicies.map((entry) => [entry.employeeId, entry])
+    ),
+  };
+};
+
+export const loadAvailabilityForEmployee = async (
+  ctx: DbCtx,
+  employeeId: string
+) => {
+  const [rules, overrides, breaks, dateBreaks, dateBreakPolicies] = await Promise.all([
+    ctx.db
+      .query("employeeAvailabilityRules")
+      .withIndex("by_employee", (q) => q.eq("employeeId", employeeId))
+      .collect(),
+    ctx.db
+      .query("employeeAvailabilityOverrides")
+      .withIndex("by_employee", (q) => q.eq("employeeId", employeeId))
+      .collect(),
+    ctx.db
+      .query("employeeAvailabilityBreaks")
+      .withIndex("by_employee", (q) => q.eq("employeeId", employeeId))
+      .collect(),
+    ctx.db
+      .query("employeeAvailabilityDateBreaks")
+      .withIndex("by_employee", (q) => q.eq("employeeId", employeeId))
+      .collect(),
+    ctx.db
+      .query("employeeAvailabilityDateBreakPolicies")
+      .withIndex("by_employee", (q) => q.eq("employeeId", employeeId))
+      .collect(),
+  ]);
+
+  return {
+    rules,
+    overrides,
+    breaks,
+    dateBreaks,
+    dateBreakPolicies,
+  };
+};
+
+export const resolveAvailabilityWindow = (
+  schedule: ScheduleDoc,
+  employeeId: string,
+  rulesByEmployeeId: Map<string, WeeklyRuleDoc>,
+  overridesByEmployeeId: Map<string, OverrideDoc>
+): AvailabilityWindow | null => {
+  const override = overridesByEmployeeId.get(employeeId);
+  if (override) {
+    if (!override.isWorking) {
+      return null;
+    }
+
+    const window = normalizeWindow(
+      schedule,
+      override.startTime,
+      override.endTime
+    );
+    return window ? { employeeId, ...window } : null;
+  }
+
+  const rule = rulesByEmployeeId.get(employeeId);
+  if (!rule) {
+    return {
+      employeeId,
+      start: schedule.open,
+      end: schedule.close,
+    };
+  }
+
+  if (!rule.isWorking) {
+    return null;
+  }
+
+  const window = normalizeWindow(schedule, rule.startTime, rule.endTime);
+  return window ? { employeeId, ...window } : null;
+};
+
+export const resolveBreakWindows = (
+  schedule: ScheduleDoc,
+  employeeId: string,
+  breaksByEmployeeId: Map<string, BreakDoc[]>,
+  dateBreaksByEmployeeId: Map<string, DateBreakDoc[]> = new Map(),
+  dateBreakPoliciesByEmployeeId: Map<string, DateBreakPolicyDoc> = new Map()
+): BreakWindow[] => {
+  const policy = dateBreakPoliciesByEmployeeId.get(employeeId);
+  const recurringBreaks = breaksByEmployeeId.get(employeeId) ?? [];
+  const dateBreaks = dateBreaksByEmployeeId.get(employeeId) ?? [];
+  const breaks =
+    policy?.mode === "replace" ? dateBreaks : [...recurringBreaks, ...dateBreaks];
+  const windows = breaks
+    .map<BreakWindow | null>((entry) => {
+      const window = normalizeWindow(schedule, entry.startTime, entry.endTime);
+      if (!window) {
+        return null;
+      }
+
+      return {
+        id: entry.id,
+        employeeId,
+        start: window.start,
+        end: window.end,
+        label: entry.label,
+      };
+    })
+    .filter((entry): entry is BreakWindow => entry !== null);
+
+  return windows.sort((left, right) => left.start.localeCompare(right.start));
+};
+
+export const isSlotWithinAvailability = (
+  window: AvailabilityWindow | null,
+  candidate: { start: string; end: string },
+  breakWindows: BreakWindow[] = []
+) => {
+  if (!window) return false;
+  if (!(candidate.start >= window.start && candidate.end <= window.end)) {
+    return false;
+  }
+  return !breakWindows.some((entry) => overlaps(entry, candidate));
+};

--- a/convex/lib/availabilityAccess.ts
+++ b/convex/lib/availabilityAccess.ts
@@ -1,0 +1,63 @@
+import { ConvexError } from "convex/values";
+
+import type { MutationCtx, QueryCtx } from "../_generated/server";
+import { requireAuthUser } from "./auth";
+import { parseISOToLocalTime } from "./dateTime";
+
+export type ViewerCtx = QueryCtx | MutationCtx;
+
+export const loadUserById = async (ctx: ViewerCtx, id: string) =>
+  ctx.db.query("users").withIndex("by_user_id", (q) => q.eq("id", id)).first();
+
+export const resolveAvailabilityActor = async (
+  ctx: ViewerCtx,
+  employeeId?: string
+) => {
+  const authUser = await requireAuthUser(ctx);
+  const viewer = await loadUserById(ctx, authUser._id);
+
+  if (!viewer) {
+    throw new ConvexError("Authenticated user record not found");
+  }
+
+  if (viewer.role === "admin") {
+    if (!employeeId) {
+      throw new ConvexError("Employee selection is required");
+    }
+    const employee = await loadUserById(ctx, employeeId);
+    if (!employee || employee.role !== "employee") {
+      throw new ConvexError("Invalid employee");
+    }
+    return { viewer, employee };
+  }
+
+  if (viewer.role !== "employee") {
+    throw new ConvexError("Forbidden");
+  }
+
+  if (employeeId && employeeId !== viewer.id) {
+    throw new ConvexError("Forbidden");
+  }
+
+  return { viewer, employee: viewer };
+};
+
+export const buildDefaultHours = async (ctx: ViewerCtx) => {
+  const nowIso = new Date().toISOString();
+  const schedule = await ctx.db
+    .query("schedules")
+    .withIndex("by_open", (q) => q.gte("open", nowIso))
+    .first();
+
+  if (!schedule) {
+    return {
+      startTime: "09:00",
+      endTime: "17:00",
+    };
+  }
+
+  return {
+    startTime: parseISOToLocalTime(schedule.open).format("HH:mm"),
+    endTime: parseISOToLocalTime(schedule.close).format("HH:mm"),
+  };
+};

--- a/convex/lib/availabilitySummary.ts
+++ b/convex/lib/availabilitySummary.ts
@@ -1,0 +1,78 @@
+import type { QueryCtx } from "../_generated/server";
+import { loadAvailabilityForDate, resolveAvailabilityWindow, resolveBreakWindows } from "./availability";
+
+type DbCtx = { db: QueryCtx["db"] };
+
+export const buildAvailabilitySummaryForDate = async (
+  ctx: DbCtx,
+  date: string
+) => {
+  const schedule = await ctx.db
+    .query("schedules")
+    .withIndex("by_date", (q) => q.eq("date", date))
+    .first();
+
+  if (!schedule) {
+    return {
+      date,
+      schedule: null,
+      employees: [],
+    };
+  }
+
+  const [employees, appointments, availabilityData] = await Promise.all([
+    ctx.db.query("users").withIndex("by_role", (q) => q.eq("role", "employee")).collect(),
+    ctx.db
+      .query("appointments")
+      .withIndex("by_schedule", (q) => q.eq("scheduleId", schedule.id))
+      .collect(),
+    loadAvailabilityForDate(ctx, date),
+  ]);
+
+  return {
+    date,
+    schedule: {
+      id: schedule.id,
+      open: schedule.open,
+      close: schedule.close,
+    },
+    employees: employees
+      .map((employee) => {
+        const availabilityWindow = resolveAvailabilityWindow(
+          schedule,
+          employee.id,
+          availabilityData.rulesByEmployeeId,
+          availabilityData.overridesByEmployeeId
+        );
+        const breaks = resolveBreakWindows(
+          schedule,
+          employee.id,
+          availabilityData.breaksByEmployeeId,
+          availabilityData.dateBreaksByEmployeeId,
+          availabilityData.dateBreakPoliciesByEmployeeId
+        );
+        const breakMode =
+          availabilityData.dateBreakPoliciesByEmployeeId.get(employee.id)?.mode ===
+          "replace"
+            ? "replace"
+            : "add";
+
+        return {
+          id: employee.id,
+          firstName: employee.firstName ?? "Employee",
+          lastName: employee.lastName ?? "",
+          availabilityWindow,
+          breaks,
+          breakMode,
+          appointmentCount: appointments.filter(
+            (appointment) => appointment.employeeId === employee.id
+          ).length,
+        };
+      })
+      .sort((left, right) =>
+        `${left.firstName} ${left.lastName}`.localeCompare(
+          `${right.firstName} ${right.lastName}`
+        )
+      ),
+  };
+};

--- a/convex/schedules.ts
+++ b/convex/schedules.ts
@@ -6,6 +6,11 @@ import { mutation, query } from "./_generated/server";
 import type { QueryCtx } from "./_generated/server";
 import type { Doc } from "./_generated/dataModel";
 import { generateRange } from "./lib/dateTime";
+import {
+  loadAvailabilityForDate,
+  resolveBreakWindows,
+  resolveAvailabilityWindow,
+} from "./lib/availability";
 import { parseName } from "./lib/names";
 import { requireAdmin } from "./lib/auth";
 
@@ -99,15 +104,48 @@ const hydrateSchedule = async (
   schedule: ScheduleDoc,
   options: { includeClient: boolean; includeCancelled: boolean }
 ) => {
-  const appointments = await loadScheduleAppointments(ctx, schedule.id, {
-    includeCancelled: options.includeCancelled,
-  });
+  const [appointments, employees, availabilityData] = await Promise.all([
+    loadScheduleAppointments(ctx, schedule.id, {
+      includeCancelled: options.includeCancelled,
+    }),
+    ctx.db
+      .query("users")
+      .withIndex("by_role", (q) => q.eq("role", "employee"))
+      .collect(),
+    loadAvailabilityForDate(ctx, schedule.date),
+  ]);
+
+  const employeeAvailability = employees
+    .map((employee) =>
+      resolveAvailabilityWindow(
+        schedule,
+        employee.id,
+        availabilityData.rulesByEmployeeId,
+        availabilityData.overridesByEmployeeId
+      )
+    )
+    .filter((window): window is NonNullable<typeof window> => window !== null)
+    .sort((a, b) => a.start.localeCompare(b.start));
+
+  const employeeBreaks = employees
+    .flatMap((employee) =>
+      resolveBreakWindows(
+        schedule,
+        employee.id,
+        availabilityData.breaksByEmployeeId,
+        availabilityData.dateBreaksByEmployeeId,
+        availabilityData.dateBreakPoliciesByEmployeeId
+      )
+    )
+    .sort((a, b) => a.start.localeCompare(b.start));
 
   return {
     id: schedule.id,
     date: schedule.date,
     open: schedule.open,
     close: schedule.close,
+    employeeAvailability,
+    employeeBreaks,
     appointments: await hydrateAppointments(ctx, appointments, {
       includeClient: options.includeClient,
     }),

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -57,6 +57,70 @@ export default defineSchema({
   })
     .index('by_token_hash', ['tokenHash'])
     .index('by_appointment_id', ['appointmentId']),
+  employeeAvailabilityRules: defineTable({
+    id: v.string(),
+    employeeId: v.string(),
+    weekday: v.number(),
+    isWorking: v.boolean(),
+    startTime: v.optional(v.string()),
+    endTime: v.optional(v.string()),
+    updatedAt: v.number(),
+  })
+    .index('by_availability_rule_id', ['id'])
+    .index('by_employee', ['employeeId'])
+    .index('by_employee_weekday', ['employeeId', 'weekday'])
+    .index('by_weekday', ['weekday']),
+  employeeAvailabilityOverrides: defineTable({
+    id: v.string(),
+    employeeId: v.string(),
+    date: v.string(),
+    isWorking: v.boolean(),
+    startTime: v.optional(v.string()),
+    endTime: v.optional(v.string()),
+    reason: v.optional(v.string()),
+    updatedAt: v.number(),
+  })
+    .index('by_availability_override_id', ['id'])
+    .index('by_employee', ['employeeId'])
+    .index('by_employee_date', ['employeeId', 'date'])
+    .index('by_date', ['date']),
+  employeeAvailabilityBreaks: defineTable({
+    id: v.string(),
+    employeeId: v.string(),
+    weekday: v.number(),
+    startTime: v.string(),
+    endTime: v.string(),
+    label: v.optional(v.string()),
+    updatedAt: v.number(),
+  })
+    .index('by_availability_break_id', ['id'])
+    .index('by_employee', ['employeeId'])
+    .index('by_employee_weekday', ['employeeId', 'weekday'])
+    .index('by_weekday', ['weekday']),
+  employeeAvailabilityDateBreaks: defineTable({
+    id: v.string(),
+    employeeId: v.string(),
+    date: v.string(),
+    startTime: v.string(),
+    endTime: v.string(),
+    label: v.optional(v.string()),
+    updatedAt: v.number(),
+  })
+    .index('by_availability_date_break_id', ['id'])
+    .index('by_employee', ['employeeId'])
+    .index('by_employee_date', ['employeeId', 'date'])
+    .index('by_date', ['date']),
+  employeeAvailabilityDateBreakPolicies: defineTable({
+    id: v.string(),
+    employeeId: v.string(),
+    date: v.string(),
+    mode: v.string(),
+    updatedAt: v.number(),
+  })
+    .index('by_availability_date_break_policy_id', ['id'])
+    .index('by_employee', ['employeeId'])
+    .index('by_employee_date', ['employeeId', 'date'])
+    .index('by_date', ['date']),
   emailOutbox: defineTable({
     id: v.string(),
     eventType: emailEventTypeValidator,


### PR DESCRIPTION
## Summary
- add employee availability management UI and Convex API on top of the landed schedule-fetch architecture
- preserve current main appointment lifecycle, shared validators, access-token flows, cancellation semantics, and email/outbox behavior
- enforce employee availability only when rules, overrides, or breaks exist; otherwise booking still falls back to the schedule open/close window

## Safety Decisions
- kept current main as source of truth for appointment access-token behavior, cancellation via status=`cancelled`, and email/outbox files
- layered availability checks into the existing appointment availability assertion path instead of replacing appointment architecture
- kept public booking data excluding cancelled appointments while private/admin schedule views still include cancelled records

## Validation
- pnpm -C client test:run -- src/routes/routes.test.tsx src/routes/EmployeeAvailability/index.test.tsx src/utils/date.test.ts
- pnpm -C convex-tests test:run -- src/appointments.test.ts src/appointmentAccess.test.ts src/availability.test.ts src/schedules.test.ts
- pnpm test:run
- pnpm typecheck