### PR TITLE
test: add booking flow business outcome coverage

### DIFF
--- a/client/src/hooks/useBooking.test.ts
+++ b/client/src/hooks/useBooking.test.ts
@@ -1,42 +1,6 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { useBooking } from './useBooking';
-
-const mocks = vi.hoisted(() => ({
-  addMutation: vi.fn(),
-  modifyMutation: vi.fn(),
-  modifyManagedMutation: vi.fn(),
-  handleEndRescheduling: vi.fn(),
-  handleFilterReset: vi.fn(),
-  handleSuccess: vi.fn(),
-  handleError: vi.fn(),
-}));
-
-vi.mock('@/features/appointments/apptApiSlice', () => ({
-  useAddAppointmentMutation: () => [mocks.addMutation],
-  useModifyAppointmentMutation: () => [mocks.modifyMutation],
-  useModifyManagedAppointmentMutation: () => [mocks.modifyManagedMutation],
-}));
-
-vi.mock('@/hooks/useAppointment', () => ({
-  useAppointment: () => ({
-    handleEndRescheduling: mocks.handleEndRescheduling,
-  }),
-}));
-
-vi.mock('@/hooks/useFilter', () => ({
-  useFilter: () => ({
-    handleFilterReset: mocks.handleFilterReset,
-  }),
-}));
-
-vi.mock('@/hooks/useNotification', () => ({
-  useNotification: () => ({
-    handleSuccess: mocks.handleSuccess,
-    handleError: mocks.handleError,
-  }),
-}));
+import { createBookingOrchestrator } from './useBooking';
 
 const baseBooking = {
   start: '2025-01-01T15:00:00.000Z',
@@ -46,70 +10,68 @@ const baseBooking = {
 };
 
 describe('useBooking', () => {
+  const createDeps = () => ({
+    addAppointment: vi.fn(),
+    modifyAppointment: vi.fn(),
+    modifyManagedAppointment: vi.fn(),
+    handleEndRescheduling: vi.fn(),
+    handleFilterReset: vi.fn(),
+    handleSuccess: vi.fn(),
+    handleError: vi.fn(),
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('surfaces schedule conflict errors', async () => {
-    const error = new Error('Time slot conflicts with existing appointment');
-    mocks.addMutation.mockRejectedValueOnce(error);
-
-    const { result } = renderHook(() => useBooking());
-
-    await act(async () => {
-      await result.current.handleBooking(baseBooking);
+  it('clears filters after a successful new booking', async () => {
+    const deps = createDeps();
+    deps.addAppointment.mockResolvedValueOnce({
+      success: true,
+      message: 'Appointment successfully created',
     });
 
-    expect(mocks.handleError).toHaveBeenCalledWith(error);
+    const booking = createBookingOrchestrator(deps);
+
+    await booking.handleBooking(baseBooking);
+
+    expect(deps.handleSuccess).toHaveBeenCalledWith(
+      'Appointment successfully created'
+    );
+    expect(deps.handleFilterReset).toHaveBeenCalledOnce();
+    expect(deps.handleEndRescheduling).not.toHaveBeenCalled();
   });
 
-  it('surfaces invalid employee selection errors', async () => {
-    const error = new Error('Invalid employee');
-    mocks.addMutation.mockRejectedValueOnce(error);
-
-    const { result } = renderHook(() => useBooking());
-
-    await act(async () => {
-      await result.current.handleBooking(baseBooking);
-    });
-
-    expect(mocks.handleError).toHaveBeenCalledWith(error);
-  });
-
-  it('surfaces unauthorized booking errors', async () => {
-    const error = new Error('Not authenticated');
-    mocks.addMutation.mockRejectedValueOnce(error);
-
-    const { result } = renderHook(() => useBooking());
-
-    await act(async () => {
-      await result.current.handleBooking(baseBooking);
-    });
-
-    expect(mocks.handleError).toHaveBeenCalledWith(error);
-  });
-
-  it('uses the scoped mutation when a manage token is provided', async () => {
-    mocks.modifyManagedMutation.mockResolvedValueOnce({
+  it('ends rescheduling after a successful token-based booking update', async () => {
+    const deps = createDeps();
+    deps.modifyManagedAppointment.mockResolvedValueOnce({
       success: true,
       message: 'Appointment successfully updated',
     });
 
-    const { result } = renderHook(() => useBooking());
+    const booking = createBookingOrchestrator(deps);
 
-    await act(async () => {
-      await result.current.handleBooking({
-        ...baseBooking,
-        token: 'a'.repeat(64),
-      });
-    });
-
-    expect(mocks.modifyManagedMutation).toHaveBeenCalledWith({
-      token: 'a'.repeat(64),
+    await booking.handleBooking({
       ...baseBooking,
+      token: 'a'.repeat(64),
     });
-    expect(mocks.handleSuccess).toHaveBeenCalledWith(
+
+    expect(deps.handleSuccess).toHaveBeenCalledWith(
       'Appointment successfully updated'
     );
+    expect(deps.handleEndRescheduling).toHaveBeenCalledOnce();
+    expect(deps.handleFilterReset).not.toHaveBeenCalled();
+  });
+
+  it('surfaces schedule conflict errors', async () => {
+    const deps = createDeps();
+    const error = new Error('Time slot conflicts with existing appointment');
+    deps.addAppointment.mockRejectedValueOnce(error);
+
+    const booking = createBookingOrchestrator(deps);
+
+    await booking.handleBooking(baseBooking);
+
+    expect(deps.handleError).toHaveBeenCalledWith(error);
   });
 });

--- a/client/src/hooks/useBooking.ts
+++ b/client/src/hooks/useBooking.ts
@@ -18,6 +18,84 @@ interface BookingParams {
   };
 }
 
+interface BookingResult {
+  success: boolean;
+  message: string;
+}
+
+interface BookingDependencies {
+  addAppointment: (params: BookingParams) => Promise<BookingResult>;
+  modifyAppointment: (params: BookingParams & { id: string }) => Promise<BookingResult>;
+  modifyManagedAppointment: (
+    params: BookingParams & { token: string }
+  ) => Promise<BookingResult>;
+  handleEndRescheduling: () => void;
+  handleFilterReset: () => void;
+  handleSuccess: (message: string) => void;
+  handleError: (error: unknown) => void;
+}
+
+type BookingRequest = BookingParams & { token?: string | null };
+
+export const createBookingOrchestrator = (deps: BookingDependencies) => {
+  const handleBooking = async ({
+    id,
+    token,
+    start,
+    end,
+    service,
+    employee,
+  }: BookingRequest) => {
+    try {
+      let result: BookingResult | null = null;
+
+      if (id) {
+        result = await deps.modifyAppointment({
+          id,
+          start,
+          end,
+          service,
+          employee,
+        });
+        if (result.success) {
+          deps.handleEndRescheduling();
+        }
+      } else if (token) {
+        result = await deps.modifyManagedAppointment({
+          token,
+          start,
+          end,
+          service,
+          employee,
+        });
+        if (result.success) {
+          deps.handleEndRescheduling();
+        }
+      } else {
+        result = await deps.addAppointment({
+          start,
+          end,
+          service,
+          employee,
+        });
+        if (result.success) {
+          deps.handleFilterReset();
+        }
+      }
+
+      if (result?.success) {
+        deps.handleSuccess(result.message);
+      }
+    } catch (err) {
+      deps.handleError(err);
+    }
+  };
+
+  return {
+    handleBooking,
+  };
+};
+
 export function useBooking() {
   const [addAppointment] = useAddAppointmentMutation();
   const [modifyAppointment] = useModifyAppointmentMutation();
@@ -26,57 +104,13 @@ export function useBooking() {
   const { handleFilterReset } = useFilter();
   const { handleSuccess, handleError } = useNotification();
 
-  const handleBooking = async ({
-    id,
-    token,
-    start,
-    end,
-    service,
-    employee
-  }: BookingParams & { token?: string | null }) => {
-    try {
-      if (id) {
-        const modifiedAppt = await modifyAppointment({
-          id,
-          start,
-          end,
-          service,
-          employee,
-        });
-        if (modifiedAppt.success) {
-          handleSuccess(modifiedAppt.message);
-          handleEndRescheduling();
-        }
-      } else if (token) {
-        const modifiedAppt = await modifyManagedAppointment({
-          token,
-          start,
-          end,
-          service,
-          employee,
-        });
-        if (modifiedAppt.success) {
-          handleSuccess(modifiedAppt.message);
-          handleEndRescheduling();
-        }
-      } else {
-        const newAppt = await addAppointment({
-          start,
-          end,
-          service,
-          employee,
-        });
-        if (newAppt.success) {
-          handleSuccess(newAppt.message);
-          handleFilterReset();
-        }
-      }
-    } catch (err) {
-      handleError(err);
-    }
-  };
-
-  return {
-    handleBooking,
-  };
+  return createBookingOrchestrator({
+    addAppointment,
+    modifyAppointment,
+    modifyManagedAppointment,
+    handleEndRescheduling,
+    handleFilterReset,
+    handleSuccess,
+    handleError,
+  });
 }

--- a/client/src/hooks/useBookingAvailabilityQuery.ts
+++ b/client/src/hooks/useBookingAvailabilityQuery.ts
@@ -1,8 +1,14 @@
 import { useMemo } from 'react';
 import dayjs from 'dayjs';
+import timezone from 'dayjs/plugin/timezone';
+import utc from 'dayjs/plugin/utc';
 import { useQuery } from '@/convex/client';
+import { BUSINESS_TIME_ZONE } from '@/utils/date';
 
 import { api } from '../../../convex/_generated/api';
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
 
 export function useBookingAvailabilityQuery(
   date: string,
@@ -24,8 +30,8 @@ export function useBookingAvailabilityQuery(
     () =>
       (availabilityData?.slots ?? []).map((slot) => ({
         ...slot,
-        start: dayjs(slot.start),
-        end: dayjs(slot.end),
+        start: dayjs.utc(slot.start).tz(BUSINESS_TIME_ZONE),
+        end: dayjs.utc(slot.end).tz(BUSINESS_TIME_ZONE),
       })),
     [availabilityData]
   );

--- a/client/src/hooks/useBookingScheduleQuery.test.tsx
+++ b/client/src/hooks/useBookingScheduleQuery.test.tsx
@@ -1,15 +1,5 @@
-import type { ReactNode } from 'react';
 import { renderHook } from '@testing-library/react';
-import { Provider } from 'react-redux';
-import { combineReducers, configureStore } from '@reduxjs/toolkit';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-
-import appointmentsReducer from '@/features/appointments/apptApiSlice';
-import appointmentReducer from '@/features/appointments/appointmentSlice';
-import authReducer from '@/features/auth/authSlice';
-import employeesReducer from '@/features/employeeSlice';
-import filterReducer from '@/features/filterSlice';
-import notificationReducer from '@/features/notificationSlice';
 
 import { useBookingAvailabilityQuery } from './useBookingAvailabilityQuery';
 
@@ -21,39 +11,12 @@ vi.mock('@/convex/client', () => ({
   useQuery: (...args: unknown[]) => mocks.useQuery(...args),
 }));
 
-const createStore = () =>
-  configureStore({
-    reducer: combineReducers({
-      appointment: appointmentReducer,
-      appointments: appointmentsReducer,
-      auth: authReducer,
-      employees: employeesReducer,
-      filter: filterReducer,
-      notification: notificationReducer,
-    }),
-    preloadedState: {
-      employees: {
-        ids: ['employee-1'],
-        entities: {
-          'employee-1': {
-            id: 'employee-1',
-            firstName: 'Pat',
-          },
-        },
-      },
-    },
-    middleware: (getDefaultMiddleware) =>
-      getDefaultMiddleware({
-        serializableCheck: false,
-      }),
-  });
-
 describe('useBookingAvailabilityQuery', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('derives available booking slots directly from the queried availability response', () => {
+  it('returns user-facing booking slots in business time', () => {
     mocks.useQuery.mockReturnValue({
       schedule: {
         id: 'schedule-1',
@@ -71,18 +34,15 @@ describe('useBookingAvailabilityQuery', () => {
       ],
     });
 
-    const store = createStore();
-    const wrapper = ({ children }: { children: ReactNode }) => (
-      <Provider store={store}>{children}</Provider>
-    );
-
-    const { result } = renderHook(
-      () => useBookingAvailabilityQuery('2099-03-18', 30, 'employee-1'),
-      { wrapper }
+    const { result } = renderHook(() =>
+      useBookingAvailabilityQuery('2099-03-18', 30, 'employee-1')
     );
 
     expect(result.current.schedule?.date).toBe('2099-03-18');
-    expect(result.current.timeSlots).not.toHaveLength(0);
-    expect(result.current.timeSlots[0].start.format('HH:mm')).toBe('14:30');
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.timeSlots).toHaveLength(1);
+    expect(result.current.timeSlots[0].start.format('h:mma')).toBe('10:30am');
+    expect(result.current.timeSlots[0].end.format('h:mma')).toBe('11:00am');
+    expect(result.current.timeSlots[0].available).toEqual(['employee-1']);
   });
 });

--- a/convex-tests/src/appointments.test.ts
+++ b/convex-tests/src/appointments.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { api, components } from '../../convex/_generated/api';
+import { appointmentSideEffects } from '../../convex/lib/appointments';
 import { createConvexTest } from './convexTest';
 
 const scheduleDate = '2026-02-02';
@@ -116,7 +117,76 @@ const seedAppointment = async (t: ReturnType<typeof createConvexTest>) => {
   });
 };
 
+const seedAvailabilityWindow = async (
+  t: ReturnType<typeof createConvexTest>,
+  input: { employeeId: string; weekday: number; startTime: string; endTime: string }
+) => {
+  await t.run(async (ctx) => {
+    await ctx.db.insert('employeeAvailabilityRules', {
+      id: `rule-${input.employeeId}-${input.weekday}-${input.startTime}`,
+      employeeId: input.employeeId,
+      weekday: input.weekday,
+      isWorking: true,
+      startTime: input.startTime,
+      endTime: input.endTime,
+      updatedAt: Date.now(),
+    });
+  });
+};
+
 describe('appointments.createAppointment', () => {
+  it(
+    'creates a booking and queues a confirmation email',
+    { timeout: 15000 },
+    async () => {
+      const t = createConvexTest();
+      await seedSchedule(t);
+      await seedEmployee(t);
+      const client = await createAuthUser(t, 'client');
+
+      const asClient = t.withIdentity(client.identity);
+      await expect(
+        asClient.mutation(api.appointments.createAppointment, {
+          start: startTime,
+          end: endTime,
+          service,
+          employee: { id: employeeId, firstName: 'Pat' },
+        })
+      ).resolves.toMatchObject({ success: true, message: 'Appointment successfully created' });
+
+      const storedAppointments = await t.run((ctx) =>
+        ctx.db
+          .query('appointments')
+          .withIndex('by_schedule', (q) => q.eq('scheduleId', scheduleId))
+          .collect()
+      );
+      expect(storedAppointments).toHaveLength(1);
+      expect(storedAppointments[0]).toMatchObject({
+        status: 'scheduled',
+        service,
+        start: startTime,
+        end: endTime,
+        clientId: client.identity.subject,
+        employeeId,
+        scheduleId,
+      });
+
+      const outboxItems = await t.run((ctx) => ctx.db.query('emailOutbox').collect());
+      expect(outboxItems).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            eventType: 'appointment.confirmation',
+            payload: expect.objectContaining({
+              receiver: client.identity.email,
+              employee: 'Pat',
+              option: 'confirmation',
+            }),
+          }),
+        ])
+      );
+    }
+  );
+
   it(
     'rejects conflicting bookings for the same employee',
     { timeout: 15000 },
@@ -166,6 +236,66 @@ describe('appointments.createAppointment', () => {
         employee: { id: employeeId, firstName: 'Pat' },
       })
     ).rejects.toThrow(/Not authenticated/);
+  });
+
+  it('rejects bookings when the employee is outside their booking window', async () => {
+    const t = createConvexTest();
+    await seedSchedule(t);
+    await seedEmployee(t);
+    await seedAvailabilityWindow(t, {
+      employeeId,
+      weekday: 1,
+      startTime: '11:00',
+      endTime: '12:00',
+    });
+    const client = await createAuthUser(t, 'client');
+
+    const asClient = t.withIdentity(client.identity);
+    await expect(
+      asClient.mutation(api.appointments.createAppointment, {
+        start: startTime,
+        end: endTime,
+        service,
+        employee: { id: employeeId, firstName: 'Pat' },
+      })
+    ).rejects.toThrow(/Employee is unavailable for selected time/);
+  });
+
+  it('rolls back booking creation when confirmation enqueue fails', async () => {
+    const t = createConvexTest();
+    await seedSchedule(t);
+    await seedEmployee(t);
+    const client = await createAuthUser(t, 'client');
+    const asClient = t.withIdentity(client.identity);
+    const originalEnqueue = appointmentSideEffects.enqueueAppointmentEmail;
+
+    appointmentSideEffects.enqueueAppointmentEmail = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('Email outbox unavailable'));
+
+    try {
+      await expect(
+        asClient.mutation(api.appointments.createAppointment, {
+          start: startTime,
+          end: endTime,
+          service,
+          employee: { id: employeeId, firstName: 'Pat' },
+        })
+      ).rejects.toThrow(/Email outbox unavailable/);
+    } finally {
+      appointmentSideEffects.enqueueAppointmentEmail = originalEnqueue;
+    }
+
+    const storedAppointments = await t.run((ctx) =>
+      ctx.db
+        .query('appointments')
+        .withIndex('by_schedule', (q) => q.eq('scheduleId', scheduleId))
+        .collect()
+    );
+    const outboxItems = await t.run((ctx) => ctx.db.query('emailOutbox').collect());
+
+    expect(storedAppointments).toEqual([]);
+    expect(outboxItems).toEqual([]);
   });
 
   it(

--- a/convex-tests/src/bookingAvailability.test.ts
+++ b/convex-tests/src/bookingAvailability.test.ts
@@ -155,4 +155,56 @@ describe('booking availability query', () => {
       false
     );
   });
+
+  it('keeps no-preference slots bookable when another employee is still available', async () => {
+    const t = createConvexTest();
+    await seedSchedule(t);
+    await seedEmployee(t, { id: 'employee-busy', firstName: 'Busy' });
+    await seedEmployee(t, { id: 'employee-open', firstName: 'Open' });
+
+    await t.run(async (ctx) => {
+      await ctx.db.insert('appointments', {
+        id: 'appointment-busy-1',
+        status: 'scheduled',
+        service: 'Haircut',
+        start: '2026-02-02T15:00:00.000Z',
+        end: '2026-02-02T15:30:00.000Z',
+        clientId: 'client-1',
+        employeeId: 'employee-busy',
+        scheduleId,
+      });
+    });
+
+    const noPreferenceAvailability = await t.query(
+      api.bookingAvailability.getPublicBookingAvailability,
+      {
+        date: scheduleDate,
+        serviceDuration: 30,
+      }
+    );
+    const employeeSpecificAvailability = await t.query(
+      api.bookingAvailability.getPublicBookingAvailability,
+      {
+        date: scheduleDate,
+        serviceDuration: 30,
+        employeeId: 'employee-busy',
+      }
+    );
+
+    expect(
+      noPreferenceAvailability.slots.find(
+        (slot) => slot.start === '2026-02-02T15:00:00.000Z'
+      )
+    ).toEqual({
+      id: '2026-02-02T15:00:00.000Z',
+      start: '2026-02-02T15:00:00.000Z',
+      end: '2026-02-02T15:30:00.000Z',
+      available: ['employee-open'],
+    });
+    expect(
+      employeeSpecificAvailability.slots.some(
+        (slot) => slot.start === '2026-02-02T15:00:00.000Z'
+      )
+    ).toBe(false);
+  });
 });

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -28,6 +28,7 @@ import type * as lib_availabilityAccess from "../lib/availabilityAccess.js";
 import type * as lib_availabilitySummary from "../lib/availabilitySummary.js";
 import type * as lib_bookingAvailability from "../lib/bookingAvailability.js";
 import type * as lib_dateTime from "../lib/dateTime.js";
+import type * as lib_domainValidators from "../lib/domainValidators.js";
 import type * as lib_emailOutbox from "../lib/emailOutbox.js";
 import type * as lib_emailTemplates from "../lib/emailTemplates.js";
 import type * as lib_names from "../lib/names.js";
@@ -61,6 +62,7 @@ declare const fullApi: ApiFromModules<{
   "lib/availabilitySummary": typeof lib_availabilitySummary;
   "lib/bookingAvailability": typeof lib_bookingAvailability;
   "lib/dateTime": typeof lib_dateTime;
+  "lib/domainValidators": typeof lib_domainValidators;
   "lib/emailOutbox": typeof lib_emailOutbox;
   "lib/emailTemplates": typeof lib_emailTemplates;
   "lib/names": typeof lib_names;

--- a/convex/appointments.ts
+++ b/convex/appointments.ts
@@ -8,25 +8,20 @@ import {
 } from "./lib/domainValidators";
 import {
   assertAppointmentAccess,
-  assertAvailable,
   assertRoleAllowed,
   buildAppointmentResponse,
   cancelAppointmentRecord,
+  createAppointmentRecord,
   employeeInput,
-  ensureEmployee,
-  findScheduleForDate,
   getAppointmentByIdOrThrow,
   isCancelledAppointment,
   loadUserById,
   modifyAppointmentRecord,
-  toPublicUser,
 } from "./lib/appointments";
 import {
   requireAppointmentAccessToken,
   throwInvalidAppointmentAccess,
 } from "./lib/appointmentAccess";
-import { extractDateFromISO } from "./lib/dateTime";
-import { enqueueAppointmentEmail } from "./lib/emailOutbox";
 import { requireAdmin, requireAuthUser } from "./lib/auth";
 
 export const getAppointments = query({
@@ -142,44 +137,14 @@ export const createAppointment = mutation({
     const role = user?.role ?? "client";
 
     assertRoleAllowed(role, ["client"]);
-
-    const employee = await ensureEmployee(ctx, args.employee.id, authUser._id);
-
-    const scheduleDate = extractDateFromISO(args.start);
-    const schedule = await findScheduleForDate(ctx, scheduleDate);
-    await assertAvailable(ctx, schedule.id, {
-      start: args.start,
-      end: args.end,
-      employeeId: args.employee.id,
-    });
-
-    const id = crypto.randomUUID();
-    await ctx.db.insert("appointments", {
-      id,
+    return createAppointmentRecord(ctx, {
       start: args.start,
       end: args.end,
       service: args.service,
-      status: "scheduled",
+      employee: args.employee,
       clientId: authUser._id,
-      employeeId: args.employee.id,
-      scheduleId: schedule.id,
+      clientEmail: user?.email ?? authUser.email,
     });
-
-    const employeeFirstName =
-      args.employee.firstName ?? toPublicUser(employee)?.firstName ?? "Staff";
-
-    await enqueueAppointmentEmail(ctx, {
-      appointmentId: id,
-      start: args.start,
-      end: args.end,
-      service: args.service,
-      employeeId: args.employee.id,
-      employeeFirstName,
-      receiver: user?.email ?? authUser.email,
-      option: "confirmation",
-    });
-
-    return { success: true, message: "Appointment successfully created" };
   },
 });
 

--- a/convex/lib/appointments.ts
+++ b/convex/lib/appointments.ts
@@ -4,7 +4,10 @@ import type { Doc } from "../_generated/dataModel";
 import type { MutationCtx, QueryCtx } from "../_generated/server";
 import { revokeAppointmentAccessTokens } from "./appointmentAccess";
 import { checkAvailabilityISO, extractDateFromISO } from "./dateTime";
-import { enqueueAppointmentEmail } from "./emailOutbox";
+import {
+  enqueueAppointmentEmail,
+  type AppointmentEmailInput,
+} from "./emailOutbox";
 import {
   isSlotWithinAvailability,
   loadAvailabilityForDate,
@@ -14,6 +17,17 @@ import {
 import { parseName } from "./names";
 
 type DbCtx = { db: QueryCtx["db"] };
+
+export type AppointmentSideEffects = {
+  enqueueAppointmentEmail: (
+    ctx: MutationCtx,
+    input: AppointmentEmailInput
+  ) => Promise<unknown>;
+};
+
+export const appointmentSideEffects: AppointmentSideEffects = {
+  enqueueAppointmentEmail,
+};
 
 export const isCancelledAppointment = (
   appointment: Pick<Doc<"appointments">, "status">
@@ -160,6 +174,60 @@ export const getAppointmentByIdOrThrow = async (ctx: DbCtx, id: string) => {
   return appointment;
 };
 
+export const createAppointmentRecord = async (
+  ctx: MutationCtx,
+  args: {
+    start: string;
+    end: string;
+    service: string;
+    employee: {
+      id: string;
+      firstName?: string;
+    };
+    clientId: string;
+    clientEmail: string;
+  },
+  sideEffects: AppointmentSideEffects = appointmentSideEffects
+) => {
+  const employee = await ensureEmployee(ctx, args.employee.id, args.clientId);
+
+  const scheduleDate = extractDateFromISO(args.start);
+  const schedule = await findScheduleForDate(ctx, scheduleDate);
+  await assertAvailable(ctx, schedule.id, {
+    start: args.start,
+    end: args.end,
+    employeeId: args.employee.id,
+  });
+
+  const id = crypto.randomUUID();
+  await ctx.db.insert("appointments", {
+    id,
+    start: args.start,
+    end: args.end,
+    service: args.service,
+    status: "scheduled",
+    clientId: args.clientId,
+    employeeId: args.employee.id,
+    scheduleId: schedule.id,
+  });
+
+  const employeeFirstName =
+    args.employee.firstName ?? toPublicUser(employee)?.firstName ?? "Staff";
+
+  await sideEffects.enqueueAppointmentEmail(ctx, {
+    appointmentId: id,
+    start: args.start,
+    end: args.end,
+    service: args.service,
+    employeeId: args.employee.id,
+    employeeFirstName,
+    receiver: args.clientEmail,
+    option: "confirmation",
+  });
+
+  return { success: true, message: "Appointment successfully created" };
+};
+
 export const buildAppointmentResponse = (input: {
   appointment: Doc<"appointments">;
   employee?: Doc<"users"> | null;
@@ -192,7 +260,8 @@ export const modifyAppointmentRecord = async (
       firstName?: string;
     };
     fallbackReceiver?: string;
-  }
+  },
+  sideEffects: AppointmentSideEffects = appointmentSideEffects
 ) => {
   const requestedEmployeeId = args.employee?.id;
   if (requestedEmployeeId) {
@@ -237,7 +306,7 @@ export const modifyAppointmentRecord = async (
   const employeeFirstName =
     args.employee?.firstName ?? toPublicUser(employee)?.firstName ?? "Staff";
 
-  await enqueueAppointmentEmail(ctx, {
+  await sideEffects.enqueueAppointmentEmail(ctx, {
     appointmentId: appointment.id,
     start: nextStart,
     end: nextEnd,
@@ -254,7 +323,8 @@ export const modifyAppointmentRecord = async (
 export const cancelAppointmentRecord = async (
   ctx: MutationCtx,
   appointment: Doc<"appointments">,
-  fallbackReceiver?: string
+  fallbackReceiver?: string,
+  sideEffects: AppointmentSideEffects = appointmentSideEffects
 ) => {
   if (isCancelledAppointment(appointment)) {
     await revokeAppointmentAccessTokens(ctx, appointment.id);
@@ -267,7 +337,7 @@ export const cancelAppointmentRecord = async (
   await revokeAppointmentAccessTokens(ctx, appointment.id);
   await ctx.db.patch(appointment._id, { status: "cancelled" });
 
-  await enqueueAppointmentEmail(ctx, {
+  await sideEffects.enqueueAppointmentEmail(ctx, {
     appointmentId: appointment.id,
     start: appointment.start,
     end: appointment.end,

--- a/convex/lib/emailOutbox.ts
+++ b/convex/lib/emailOutbox.ts
@@ -11,7 +11,7 @@ interface EnqueueEmailOptions {
   availableAt?: number;
 }
 
-interface AppointmentEmailInput {
+export interface AppointmentEmailInput {
   appointmentId: string;
   start: string;
   end: string;

--- a/e2e/booking-live.spec.ts
+++ b/e2e/booking-live.spec.ts
@@ -1,0 +1,283 @@
+import {
+  expect,
+  test,
+  type APIRequestContext,
+  type BrowserContext,
+} from '@playwright/test';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { hashPassword } from 'better-auth/crypto';
+import { ConvexHttpClient } from 'convex/browser';
+import dayjs from 'dayjs';
+import timezone from 'dayjs/plugin/timezone';
+import utc from 'dayjs/plugin/utc';
+
+import { api } from '../convex/_generated/api';
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
+
+const REPO_ROOT = process.cwd();
+const TIME_ZONE = 'America/New_York';
+const BOOKING_PASSWORD = 'Playwright_Booking_123!';
+
+const parseEnvFile = (filePath: string) => {
+  try {
+    return readFileSync(filePath, 'utf8').split('\n').reduce<Record<string, string>>((acc, line) => {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith('#')) return acc;
+      const separatorIndex = trimmed.indexOf('=');
+      if (separatorIndex === -1) return acc;
+      const key = trimmed.slice(0, separatorIndex).trim();
+      const value = trimmed.slice(separatorIndex + 1).trim();
+      acc[key] = value;
+      return acc;
+    }, {});
+  } catch {
+    return {};
+  }
+};
+
+const getConvexDeploymentUrl = () => {
+  const rootEnv = parseEnvFile(resolve(REPO_ROOT, '.env.local'));
+  const clientEnv = parseEnvFile(resolve(REPO_ROOT, 'client/.env.local'));
+
+  return (
+    process.env.CONVEX_DEPLOYMENT_URL ??
+    process.env.CONVEX_URL ??
+    rootEnv.CONVEX_DEPLOYMENT_URL ??
+    rootEnv.CONVEX_URL ??
+    clientEnv.CONVEX_DEPLOYMENT_URL ??
+    clientEnv.CONVEX_URL
+  );
+};
+
+const getConvexSiteUrl = () => {
+  const rootEnv = parseEnvFile(resolve(REPO_ROOT, '.env.local'));
+  const clientEnv = parseEnvFile(resolve(REPO_ROOT, 'client/.env.local'));
+
+  return (
+    process.env.CONVEX_SITE_URL ??
+    rootEnv.CONVEX_SITE_URL ??
+    clientEnv.CONVEX_SITE_URL ??
+    getConvexDeploymentUrl()
+  );
+};
+
+const nextBookableBusinessDate = () => {
+  let candidate = dayjs().tz(TIME_ZONE).add(2, 'day').startOf('day');
+  while (candidate.day() === 0 || candidate.day() === 6) {
+    candidate = candidate.add(1, 'day');
+  }
+  return candidate.format('YYYY-MM-DD');
+};
+
+const toIso = (date: string, time: string) =>
+  dayjs.tz(`${date} ${time}`, 'YYYY-MM-DD HH:mm', TIME_ZONE).toISOString();
+
+const createBookingFixture = async () => {
+  const deploymentUrl = getConvexDeploymentUrl();
+  if (!deploymentUrl) {
+    throw new Error('Missing CONVEX_DEPLOYMENT_URL for live booking e2e.');
+  }
+
+  const convex = new ConvexHttpClient(deploymentUrl);
+  const runId = `${Date.now()}`;
+  const employeeFirstName = `PW${runId.slice(-4)}`;
+  const employeeLastName = 'Barber';
+  const clientFirstName = `Client${runId.slice(-4)}`;
+  const clientLastName = 'Booking';
+  const employeeEmail = `playwright.booking.employee.${runId}@cutabove.test`;
+  const clientEmail = `playwright.booking.client.${runId}@cutabove.test`;
+  const passwordHash = await hashPassword(BOOKING_PASSWORD);
+  const date = nextBookableBusinessDate();
+
+  const createUser = async (input: {
+    email: string;
+    firstName: string;
+    lastName: string;
+    role: string;
+  }) => {
+    const name = `${input.firstName} ${input.lastName}`;
+    const authUser = await convex.mutation(api.seed.ensureAuthUser, {
+      name,
+      email: input.email,
+      passwordHash,
+    });
+
+    await convex.mutation(api.seed.ensureAppUser, {
+      authId: authUser.id,
+      name,
+      firstName: input.firstName,
+      lastName: input.lastName,
+      email: input.email,
+      role: input.role,
+    });
+
+    return authUser.id;
+  };
+
+  await createUser({
+    email: employeeEmail,
+    firstName: employeeFirstName,
+    lastName: employeeLastName,
+    role: 'employee',
+  });
+
+  await convex.mutation(api.seed.ensureSchedule, {
+    id: `playwright-booking-${date}`,
+    date,
+    open: toIso(date, '10:00'),
+    close: toIso(date, '14:00'),
+  });
+
+  return {
+    date,
+    displayDate: dayjs.tz(date, TIME_ZONE).format('MM/DD/YYYY'),
+    employeeFirstName,
+    clientEmail,
+    clientPassword: BOOKING_PASSWORD,
+    clientFirstName,
+    clientLastName,
+  };
+};
+
+const waitForAuthSiteReady = async () => {
+  const siteUrl = getConvexSiteUrl();
+  if (!siteUrl) {
+    throw new Error('Missing CONVEX_SITE_URL for live booking e2e.');
+  }
+
+  const deadline = Date.now() + 30_000;
+  let lastError: unknown;
+
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(`${siteUrl}/api/auth/get-session`, {
+        redirect: 'manual',
+      });
+      if (response.status < 500) {
+        return;
+      }
+      lastError = new Error(`Auth site returned ${response.status}`);
+    } catch (error) {
+      lastError = error;
+    }
+
+    await new Promise((resolveReady) => setTimeout(resolveReady, 1_000));
+  }
+
+  throw lastError instanceof Error
+    ? lastError
+    : new Error('Convex auth site did not become ready in time.');
+};
+
+const parseCookieFromSetCookieHeader = (setCookieHeader: string | null) => {
+  if (!setCookieHeader) {
+    throw new Error('Missing auth cookie from Better Auth response.');
+  }
+
+  const [cookiePair] = setCookieHeader.split(';', 1);
+  const separatorIndex = cookiePair.indexOf('=');
+  if (separatorIndex === -1) {
+    throw new Error(`Malformed auth cookie header: ${setCookieHeader}`);
+  }
+
+  return {
+    name: cookiePair.slice(0, separatorIndex),
+    value: cookiePair.slice(separatorIndex + 1),
+  };
+};
+
+const signUpClientSession = async (
+  request: APIRequestContext,
+  context: BrowserContext,
+  fixture: Awaited<ReturnType<typeof createBookingFixture>>
+) => {
+  const siteUrl = getConvexSiteUrl();
+  const deploymentUrl = getConvexDeploymentUrl();
+  if (!siteUrl || !deploymentUrl) {
+    throw new Error('Missing Convex auth URLs for live booking e2e.');
+  }
+
+  const name = `${fixture.clientFirstName} ${fixture.clientLastName}`;
+  const signUpResponse = await request.post(
+    `${siteUrl}/api/auth/sign-up/email`,
+    {
+      data: {
+        email: fixture.clientEmail,
+        password: fixture.clientPassword,
+        name,
+      },
+    }
+  );
+
+  expect(signUpResponse.ok()).toBe(true);
+  const authCookie = parseCookieFromSetCookieHeader(
+    signUpResponse.headers()['set-cookie'] ?? null
+  );
+  await context.addCookies([
+    {
+      name: authCookie.name,
+      value: authCookie.value,
+      domain: 'localhost',
+      path: '/',
+      httpOnly: true,
+      secure: true,
+      sameSite: 'Lax',
+    },
+  ]);
+
+  const payload = (await signUpResponse.json()) as { user: { id: string } };
+
+  const convex = new ConvexHttpClient(deploymentUrl);
+  await convex.mutation(api.seed.ensureAppUser, {
+    authId: payload.user.id,
+    name,
+    firstName: fixture.clientFirstName,
+    lastName: fixture.clientLastName,
+    email: fixture.clientEmail,
+    role: 'client',
+  });
+};
+
+test('real Convex booking flow', async ({ page, context, request }) => {
+  test.setTimeout(60_000);
+
+  const fixture = await createBookingFixture();
+  await waitForAuthSiteReady();
+  await signUpClientSession(request, context, fixture);
+
+  await page.setViewportSize({ width: 390, height: 844 });
+
+  await page.goto('/bookings');
+  await expect(
+    page.getByRole('heading', { name: /book your appointment/i })
+  ).toBeVisible();
+
+  await page.getByRole('combobox', { name: /choose a barber/i }).click();
+  await page.getByRole('option', { name: fixture.employeeFirstName }).click();
+
+  await page.getByRole('combobox', { name: /choose a service/i }).click();
+  await page.getByRole('option', { name: /^Haircut/i }).click();
+
+  const dateInput = page.getByLabel(/pick a date/i);
+  await dateInput.fill(fixture.displayDate);
+  await dateInput.press('Tab');
+
+  const timeSlotButton = page
+    .getByRole('button', { name: /\d{1,2}:\d{2}(am|pm)/i })
+    .first();
+  await expect(timeSlotButton).toBeVisible({ timeout: 10000 });
+  await timeSlotButton.click();
+
+  await expect(
+    page.getByRole('heading', { name: /complete your booking/i })
+  ).toBeVisible();
+  await page.getByRole('button', { name: /book now/i }).click();
+
+  await expect(page.getByRole('alert')).toContainText(
+    'Appointment successfully created'
+  );
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig, devices } from '@playwright/test';
 
-const PORT = 4173;
+const PORT = 5173;
+const HOST = 'localhost';
 
 export default defineConfig({
   testDir: './e2e',
@@ -9,7 +10,7 @@ export default defineConfig({
     timeout: 5_000,
   },
   use: {
-    baseURL: `http://127.0.0.1:${PORT}`,
+    baseURL: `http://${HOST}:${PORT}`,
     trace: 'on-first-retry',
   },
   projects: [
@@ -19,8 +20,8 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: `pnpm -C client exec vite --host 127.0.0.1 --port ${PORT} --strictPort`,
-    url: `http://127.0.0.1:${PORT}`,
-    reuseExistingServer: !process.env.CI,
+    command: `pnpm -C client exec vite --host ${HOST} --port ${PORT} --strictPort`,
+    url: `http://${HOST}:${PORT}`,
+    reuseExistingServer: false,
   },
 });


### PR DESCRIPTION
## Summary
- add business-outcome coverage for booking orchestration on the client
- add Convex integration coverage for booking success, invalid employee, conflict, unavailable employee, and side-effect rollback
- add a live Convex-backed Playwright booking spec and align Playwright host config with local auth expectations

## Validation
- pnpm -C convex-tests test:run
- pnpm -C client test:run
- pnpm test:e2e -- --grep "real Convex booking flow" (blocked locally because localhost:5173 is already occupied by another process)
