### PR TITLE
Add auth/session integration coverage

### DIFF
--- a/client/src/hooks/authSessionAdapter.ts
+++ b/client/src/hooks/authSessionAdapter.ts
@@ -1,0 +1,57 @@
+import { useQuery } from 'convex/react';
+
+import { authClient } from '@/convex/authClient';
+import { api } from '../../../convex/_generated/api';
+
+export interface AuthSessionUser {
+  email?: string | null;
+  name?: string | null;
+}
+
+export interface AuthSessionData {
+  user?: AuthSessionUser | null;
+}
+
+export interface CurrentUserRecord {
+  id: string;
+  email: string;
+  role: string;
+  name?: string;
+  firstName?: string;
+  lastName?: string;
+  createdAt?: number;
+  updatedAt?: number;
+}
+
+type AuthClientResult = { error?: unknown } | undefined;
+
+export interface AuthSessionAdapter {
+  useSession: () => {
+    data: AuthSessionData | null | undefined;
+    isPending: boolean;
+  };
+  useCurrentUser: () => CurrentUserRecord | null | undefined;
+  signInEmail: (args: { email: string; password: string }) => Promise<AuthClientResult>;
+  signOut: () => Promise<AuthClientResult>;
+  changeEmail: (args: { newEmail: string }) => Promise<AuthClientResult>;
+  changePassword: (args: {
+    currentPassword: string;
+    newPassword: string;
+  }) => Promise<AuthClientResult>;
+  deleteUser: (args: Record<string, never>) => Promise<AuthClientResult>;
+  resetPassword: (args: {
+    token: string;
+    newPassword: string;
+  }) => Promise<AuthClientResult>;
+}
+
+export const authSessionAdapter: AuthSessionAdapter = {
+  useSession: () => authClient.useSession(),
+  useCurrentUser: () => useQuery(api.auth.getCurrentUser, {}),
+  signInEmail: (args) => authClient.signIn.email(args),
+  signOut: () => authClient.signOut(),
+  changeEmail: (args) => authClient.changeEmail(args),
+  changePassword: (args) => authClient.changePassword(args),
+  deleteUser: (args) => authClient.deleteUser(args),
+  resetPassword: (args) => authClient.resetPassword(args),
+};

--- a/client/src/hooks/useAuth.test.tsx
+++ b/client/src/hooks/useAuth.test.tsx
@@ -1,102 +1,142 @@
-import type { ReactNode } from 'react';
 import { Provider } from 'react-redux';
-import { MemoryRouter } from 'react-router';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { act, renderHook, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 
+import { useAppSelector } from '@/app/hooks';
+import Notification from '@/components/Notification';
+import { selectCurrentUser } from '@/features/auth/authSlice';
 import { createTestStore } from '@/test/test-utils';
 import { useAuth } from './useAuth';
+import type { AuthSessionAdapter } from './authSessionAdapter';
 
-const mocks = vi.hoisted(() => ({
-  signInEmail: vi.fn(),
-  signOut: vi.fn(),
-  useSession: vi.fn(),
-  navigate: vi.fn(),
-  locationState: { state: { from: '/account' } },
-}));
-
-vi.mock('@/convex/authClient', () => ({
-  authClient: {
-    signIn: { email: mocks.signInEmail },
-    signOut: mocks.signOut,
-    useSession: mocks.useSession,
-    changeEmail: vi.fn(),
-    changePassword: vi.fn(),
-    deleteUser: vi.fn(),
-    resetPassword: vi.fn(),
-  },
-}));
-
-vi.mock('react-router', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('react-router')>();
-  return {
-    ...actual,
-    useNavigate: () => mocks.navigate,
-    useLocation: () => mocks.locationState,
-  };
+const createAdapter = (
+  overrides: Partial<AuthSessionAdapter> = {}
+): AuthSessionAdapter => ({
+  useSession: () => ({ data: null, isPending: false }),
+  useCurrentUser: () => null,
+  signInEmail: vi.fn().mockResolvedValue({}),
+  signOut: vi.fn().mockResolvedValue({}),
+  changeEmail: vi.fn().mockResolvedValue({}),
+  changePassword: vi.fn().mockResolvedValue({}),
+  deleteUser: vi.fn().mockResolvedValue({}),
+  resetPassword: vi.fn().mockResolvedValue({}),
+  ...overrides,
 });
 
-vi.mock('convex/react', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('convex/react')>();
-  return {
-    ...actual,
-    useQuery: vi.fn(() => null),
-  };
-});
+function AuthHarness({ adapter }: { adapter: AuthSessionAdapter }) {
+  const { user, role, isAuthLoading, handleLogin, handleLogout } = useAuth(adapter);
+  const storedUser = useAppSelector(selectCurrentUser);
 
-const createWrapper = (store: ReturnType<typeof createTestStore>) => {
-  function AuthTestWrapper({ children }: { children: ReactNode }) {
-    return (
-      <Provider store={store}>
-        <MemoryRouter>{children}</MemoryRouter>
-      </Provider>
-    );
-  }
-
-  return AuthTestWrapper;
-};
+  return (
+    <>
+      <p data-testid="resolved-user">{user ?? 'none'}</p>
+      <p data-testid="resolved-role">{role ?? 'none'}</p>
+      <p data-testid="loading">{String(isAuthLoading)}</p>
+      <p data-testid="stored-user">{storedUser ?? 'none'}</p>
+      <button type="button" onClick={() => void handleLogin(' Test@Example.com ', 'pw')}>
+        Login
+      </button>
+      <button type="button" onClick={() => void handleLogout()}>
+        Logout
+      </button>
+      <Notification />
+    </>
+  );
+}
 
 beforeEach(() => {
   vi.clearAllMocks();
-  mocks.locationState.state = { from: '/account' };
-  mocks.useSession.mockReturnValue({ data: null, isPending: false });
-  mocks.signInEmail.mockResolvedValue({});
-  mocks.signOut.mockResolvedValue({});
 });
 
 describe('useAuth', () => {
   it('logs in with cleaned email', async () => {
     const store = createTestStore();
-    const { result } = renderHook(() => useAuth(), {
-      wrapper: createWrapper(store),
-    });
+    const adapter = createAdapter();
 
-    await act(async () => {
-      await result.current.handleLogin(' Test@Example.com ', 'pw');
-    });
+    render(
+      <Provider store={store}>
+        <AuthHarness adapter={adapter} />
+      </Provider>
+    );
 
-    expect(mocks.signInEmail).toHaveBeenCalledWith({
-      email: 'test@example.com',
-      password: 'pw',
+    fireEvent.click(screen.getByRole('button', { name: 'Login' }));
+
+    await waitFor(() => {
+      expect(adapter.signInEmail).toHaveBeenCalledWith({
+        email: 'test@example.com',
+        password: 'pw',
+      });
     });
-    expect(mocks.navigate).not.toHaveBeenCalled();
   });
 
-  it('logs out and clears auth state', async () => {
+  it('clears persisted auth when Better Auth reports no active session', async () => {
+    const store = createTestStore({
+      auth: { user: 'persisted@example.com', role: 'client' },
+    });
+    const adapter = createAdapter({
+      useCurrentUser: () => null,
+    });
+
+    render(
+      <Provider store={store}>
+        <AuthHarness adapter={adapter} />
+      </Provider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('stored-user')).toHaveTextContent('none');
+    });
+  });
+
+  it('shows a visible logout error when sign-out fails', async () => {
     const store = createTestStore({
       auth: { user: 'test@example.com', role: 'client' },
     });
-    const { result } = renderHook(() => useAuth(), {
-      wrapper: createWrapper(store),
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const adapter = createAdapter({
+      useSession: () => ({
+        data: { user: { email: 'test@example.com', name: 'Test User' } },
+        isPending: false,
+      }),
+      signOut: vi.fn().mockRejectedValue(new Error('network down')),
     });
 
-    await act(async () => {
-      await result.current.handleLogout();
-    });
+    render(
+      <Provider store={store}>
+        <AuthHarness adapter={adapter} />
+      </Provider>
+    );
 
-    expect(mocks.signOut).toHaveBeenCalled();
+    fireEvent.click(screen.getByRole('button', { name: 'Logout' }));
+
+    expect(adapter.signOut).toHaveBeenCalled();
+
     await waitFor(() => {
-      expect(store.getState().auth).toEqual({ user: null, role: null });
+      expect(screen.getByText(/error: could not log out\. backend unreachable\./i)).toBeInTheDocument();
     });
+
+    expect(screen.getByTestId('stored-user')).toHaveTextContent('test@example.com');
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('keeps loading until the current user record resolves for an active session', () => {
+    const store = createTestStore();
+    const adapter = createAdapter({
+      useSession: () => ({
+        data: { user: { email: 'admin@example.com', name: 'Admin User' } },
+        isPending: false,
+      }),
+      useCurrentUser: () => undefined,
+    });
+
+    render(
+      <Provider store={store}>
+        <AuthHarness adapter={adapter} />
+      </Provider>
+    );
+
+    expect(screen.getByTestId('resolved-user')).toHaveTextContent('admin@example.com');
+    expect(screen.getByTestId('resolved-role')).toHaveTextContent('none');
+    expect(screen.getByTestId('loading')).toHaveTextContent('true');
   });
 });

--- a/client/src/hooks/useAuth.ts
+++ b/client/src/hooks/useAuth.ts
@@ -7,12 +7,13 @@ import {
   selectCurrentUserRole,
   setCredentials,
 } from '@/features/auth/authSlice';
-import { authClient } from '@/convex/authClient';
 import { CONVEX_SITE_URL, CONVEX_URL } from '@/convex/env';
-import { useQuery } from 'convex/react';
-import { api } from '../../../convex/_generated/api';
 import { useNotification } from './useNotification';
 import { cleanEmail } from '@/utils/email';
+import {
+  authSessionAdapter,
+  type AuthSessionAdapter,
+} from './authSessionAdapter';
 
 interface EmailChangePayload {
   email: string;
@@ -28,12 +29,19 @@ interface PasswordResetPayload {
   password: string;
 }
 
-export function useAuth() {
+const publicProblem = (detail: string) => ({
+  type: 'about:blank',
+  title: detail,
+  status: 500,
+  detail,
+});
+
+export function useAuth(adapter: AuthSessionAdapter = authSessionAdapter) {
   const dispatch = useAppDispatch();
   const storedUser = useAppSelector(selectCurrentUser);
   const storedRole = useAppSelector(selectCurrentUserRole);
-  const session = authClient.useSession();
-  const currentUser = useQuery(api.auth.getCurrentUser, {});
+  const session = adapter.useSession();
+  const currentUser = adapter.useCurrentUser();
 
   const { handleSuccess, handleError } = useNotification();
 
@@ -68,7 +76,7 @@ export function useAuth() {
 
   const handleLogin = async (email: string, password: string) => {
     try {
-      const result = await authClient.signIn.email({
+      const result = await adapter.signInEmail({
         email: cleanEmail(email),
         password,
       });
@@ -84,7 +92,7 @@ export function useAuth() {
 
   const handleLogout = async () => {
     try {
-      const result = await authClient.signOut();
+      const result = await adapter.signOut();
       if (result?.error) {
         handleError(result.error);
         return;
@@ -100,13 +108,13 @@ export function useAuth() {
           error,
         });
       }
-      handleError('Could not log out. Backend unreachable.', error);
+      handleError(publicProblem('Could not log out. Backend unreachable.'), error);
     }
   };
 
   const handleUserEmailChange = async (newEmailObj: EmailChangePayload) => {
     try {
-      const result = await authClient.changeEmail({
+      const result = await adapter.changeEmail({
         newEmail: cleanEmail(newEmailObj.email),
       });
       if (result?.error) {
@@ -122,7 +130,7 @@ export function useAuth() {
 
   const handleUserPasswordChange = async (newPasswordObj: PasswordChangePayload) => {
     try {
-      const result = await authClient.changePassword({
+      const result = await adapter.changePassword({
         currentPassword: newPasswordObj.currentPassword,
         newPassword: newPasswordObj.newPassword,
       });
@@ -139,7 +147,7 @@ export function useAuth() {
 
   const handleUserDelete = async () => {
     try {
-      const result = await authClient.deleteUser({});
+      const result = await adapter.deleteUser({});
       if (result?.error) {
         handleError(result.error);
         return;
@@ -153,7 +161,7 @@ export function useAuth() {
 
   const handleUserPasswordReset = async (newCredentials: PasswordResetPayload) => {
     try {
-      const result = await authClient.resetPassword({
+      const result = await adapter.resetPassword({
         token: newCredentials.token,
         newPassword: newCredentials.password,
       });

--- a/client/src/routes/RequireAuth/index.test.tsx
+++ b/client/src/routes/RequireAuth/index.test.tsx
@@ -1,0 +1,171 @@
+import type { ReactNode } from 'react';
+import { Provider } from 'react-redux';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router';
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { ThemeProvider, responsiveFontSizes } from '@mui/material';
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
+import { render, screen } from '@testing-library/react';
+
+import { theme } from '@/styles/styles';
+import { createTestStore } from '@/test/test-utils';
+import RequireAuth from '.';
+
+const authState = {
+  session: { data: null, isPending: false },
+  currentUser: null as
+    | {
+        id: string;
+        email: string;
+        role: string;
+        name?: string;
+        firstName?: string;
+        lastName?: string;
+      }
+    | null
+    | undefined,
+};
+
+vi.mock('@/hooks/authSessionAdapter', () => ({
+  authSessionAdapter: {
+    useSession: () => authState.session,
+    useCurrentUser: () => authState.currentUser,
+    signInEmail: vi.fn(),
+    signOut: vi.fn(),
+    changeEmail: vi.fn(),
+    changePassword: vi.fn(),
+    deleteUser: vi.fn(),
+    resetPassword: vi.fn(),
+  },
+}));
+
+const renderWithProviders = (ui: ReactNode, route: string, preloadedState = {}) => {
+  const store = createTestStore(preloadedState);
+
+  function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[route]}>
+          <LocalizationProvider dateAdapter={AdapterDayjs}>
+            <ThemeProvider theme={responsiveFontSizes(theme)}>{children}</ThemeProvider>
+          </LocalizationProvider>
+        </MemoryRouter>
+      </Provider>
+    );
+  }
+
+  return {
+    store,
+    ...render(<>{ui}</>, { wrapper: Wrapper }),
+  };
+};
+
+function LoginEcho() {
+  const location = useLocation();
+  const state = location.state as { from?: string } | null;
+
+  return (
+    <div>
+      <p>Login Page</p>
+      <p data-testid="login-path">
+        {location.pathname}
+        {location.search}
+      </p>
+      <p data-testid="login-state">{state?.from ?? 'none'}</p>
+    </div>
+  );
+}
+
+describe('RequireAuth auth/session integration', () => {
+  beforeEach(() => {
+    authState.session = { data: null, isPending: false };
+    authState.currentUser = null;
+  });
+
+  it('redirects unauthenticated access to login with a returnTo value', () => {
+    renderWithProviders(
+      <Routes>
+        <Route path="/login" element={<LoginEcho />} />
+        <Route element={<RequireAuth />}>
+          <Route path="/account" element={<div>Account Page</div>} />
+        </Route>
+      </Routes>,
+      '/account?tab=security#section'
+    );
+
+    expect(screen.getByText('Login Page')).toBeInTheDocument();
+    expect(screen.getByTestId('login-path')).toHaveTextContent(
+      '/login?returnTo=%2Faccount%3Ftab%3Dsecurity%23section'
+    );
+    expect(screen.getByTestId('login-state')).toHaveTextContent(
+      '/account?tab=security#section'
+    );
+  });
+
+  it('waits for current-user resolution before showing an admin-only route', () => {
+    authState.session = {
+      data: { user: { email: 'admin@example.com', name: 'Admin User' } },
+      isPending: false,
+    };
+    authState.currentUser = undefined;
+
+    const view = renderWithProviders(
+      <Routes>
+        <Route element={<RequireAuth requiredRole="admin" />}>
+          <Route path="/dashboard" element={<div>Dashboard Content</div>} />
+        </Route>
+      </Routes>,
+      '/dashboard'
+    );
+
+    expect(screen.queryByText('Dashboard Content')).not.toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: /not allowed/i })).not.toBeInTheDocument();
+
+    authState.currentUser = {
+      id: 'user_1',
+      email: 'admin@example.com',
+      role: 'admin',
+      name: 'Admin User',
+      firstName: 'Admin',
+      lastName: 'User',
+    };
+
+    view.rerender(
+      <Routes>
+        <Route element={<RequireAuth requiredRole="admin" />}>
+          <Route path="/dashboard" element={<div>Dashboard Content</div>} />
+        </Route>
+      </Routes>
+    );
+
+    expect(screen.getByText('Dashboard Content')).toBeInTheDocument();
+  });
+
+  it('shows access denied when an authenticated non-admin hits an admin-only route', () => {
+    authState.session = {
+      data: { user: { email: 'employee@example.com', name: 'Employee User' } },
+      isPending: false,
+    };
+    authState.currentUser = {
+      id: 'user_2',
+      email: 'employee@example.com',
+      role: 'employee',
+      name: 'Employee User',
+      firstName: 'Employee',
+      lastName: 'User',
+    };
+
+    renderWithProviders(
+      <Routes>
+        <Route element={<RequireAuth requiredRole="admin" />}>
+          <Route path="/dashboard" element={<div>Dashboard Content</div>} />
+        </Route>
+      </Routes>,
+      '/dashboard'
+    );
+
+    expect(screen.getByRole('heading', { name: /not allowed/i })).toBeInTheDocument();
+    expect(screen.getByText(/restricted to admin accounts/i)).toBeInTheDocument();
+    expect(screen.queryByText('Dashboard Content')).not.toBeInTheDocument();
+  });
+});

--- a/client/src/routes/routes.test.tsx
+++ b/client/src/routes/routes.test.tsx
@@ -138,22 +138,6 @@ describe('Public Routes', () => {
   });
 });
 
-describe('Protected Routes - Unauthenticated', () => {
-  it('redirects to login when not authenticated', () => {
-    const TestRoutes = () => (
-      <Routes>
-        <Route path="/login" element={<div>Login Page</div>} />
-        <Route element={<RequireAuth />}>
-          <Route path="/account" element={<Account />} />
-        </Route>
-      </Routes>
-    );
-
-    render(<TestRoutes />, { route: '/account' });
-    expect(screen.getByText('Login Page')).toBeInTheDocument();
-  });
-});
-
 describe('Protected Routes - Authenticated', () => {
   it('renders Account page when authenticated', () => {
     mockAuthState.user = 'test@example.com';
@@ -214,39 +198,6 @@ describe('Protected Routes - Authenticated', () => {
     expect(
       screen.queryByRole('link', { name: /^add a new schedule$/i })
     ).not.toBeInTheDocument();
-  });
-});
-
-describe('Admin Routes', () => {
-  it('shows access denied for non-admin accessing admin routes', () => {
-    mockAuthState.user = 'user@example.com';
-    mockAuthState.role = 'user';
-    const TestRoutes = () => (
-      <Routes>
-        <Route element={<RequireAuth requiredRole="admin" />}>
-          <Route path="/dashboard" element={<div>Dashboard</div>} />
-        </Route>
-      </Routes>
-    );
-
-    render(<TestRoutes />, { route: '/dashboard' });
-    expect(screen.getByRole('heading', { name: /not allowed/i })).toBeInTheDocument();
-  });
-
-  it('allows admin to access admin routes', () => {
-    mockAuthState.user = 'admin@example.com';
-    mockAuthState.role = 'admin';
-    const TestRoutes = () => (
-      <Routes>
-        <Route element={<RequireAuth requiredRole="admin" />}>
-          <Route path="/dashboard" element={<div>Dashboard Content</div>} />
-        </Route>
-      </Routes>
-    );
-
-    render(<TestRoutes />, { route: '/dashboard' });
-
-    expect(screen.getByText('Dashboard Content')).toBeInTheDocument();
   });
 });
 

--- a/convex-tests/src/authSession.test.ts
+++ b/convex-tests/src/authSession.test.ts
@@ -1,0 +1,305 @@
+import { describe, expect, it } from 'vitest';
+
+import { api, components, internal } from '../../convex/_generated/api';
+import { createConvexTest } from './convexTest';
+
+const createBetterAuthUser = async (
+  t: ReturnType<typeof createConvexTest>,
+  input: {
+    name: string;
+    email: string;
+    createdAt?: number;
+    updatedAt?: number;
+  }
+) => {
+  const now = input.createdAt ?? Date.now();
+  const authUser = await t.mutation(components.betterAuth.adapter.create, {
+    input: {
+      model: 'user',
+      data: {
+        name: input.name,
+        email: input.email,
+        emailVerified: false,
+        createdAt: now,
+        updatedAt: input.updatedAt ?? now,
+      },
+    },
+  });
+
+  const authUserId =
+    (authUser as { id?: string; _id?: string }).id ??
+    (authUser as { _id?: string })._id;
+  if (!authUserId) {
+    throw new Error('Auth user id missing from Better Auth adapter response.');
+  }
+
+  await t.mutation(internal.auth.onCreate, {
+    model: 'user',
+    doc: authUser,
+  });
+
+  return { authUserId, authUser };
+};
+
+const createUnsyncedAuthIdentity = async (
+  t: ReturnType<typeof createConvexTest>,
+  input: {
+    name: string;
+    email: string;
+  }
+) => {
+  const now = Date.now();
+  const authUser = await t.mutation(components.betterAuth.adapter.create, {
+    input: {
+      model: 'user',
+      data: {
+        name: input.name,
+        email: input.email,
+        emailVerified: false,
+        createdAt: now,
+        updatedAt: now,
+      },
+    },
+  });
+
+  const authUserId =
+    (authUser as { id?: string; _id?: string }).id ??
+    (authUser as { _id?: string })._id;
+  if (!authUserId) {
+    throw new Error('Auth user id missing from Better Auth adapter response.');
+  }
+
+  const session = await t.mutation(components.betterAuth.adapter.create, {
+    input: {
+      model: 'session',
+      data: {
+        userId: authUserId,
+        token: `session-${authUserId}`,
+        createdAt: now,
+        updatedAt: now,
+        expiresAt: now + 60 * 60 * 1000,
+      },
+    },
+  });
+
+  const sessionId =
+    (session as { id?: string; _id?: string }).id ??
+    (session as { _id?: string })._id;
+  if (!sessionId) {
+    throw new Error('Session id missing from Better Auth adapter response.');
+  }
+
+  return {
+    identity: {
+      subject: authUserId,
+      sessionId,
+      name: input.name,
+      email: input.email,
+    },
+    authUserId,
+    now,
+  };
+};
+
+const createSyncedAuthIdentity = async (
+  t: ReturnType<typeof createConvexTest>,
+  input: {
+    name: string;
+    email: string;
+  }
+) => {
+  const { authUserId } = await createBetterAuthUser(t, input);
+  const now = Date.now();
+
+  const session = await t.mutation(components.betterAuth.adapter.create, {
+    input: {
+      model: 'session',
+      data: {
+        userId: authUserId,
+        token: `session-${authUserId}`,
+        createdAt: now,
+        updatedAt: now,
+        expiresAt: now + 60 * 60 * 1000,
+      },
+    },
+  });
+
+  const sessionId =
+    (session as { id?: string; _id?: string }).id ??
+    (session as { _id?: string })._id;
+  if (!sessionId) {
+    throw new Error('Session id missing from Better Auth adapter response.');
+  }
+
+  return {
+    identity: {
+      subject: authUserId,
+      sessionId,
+      name: input.name,
+      email: input.email,
+    },
+    authUserId,
+  };
+};
+
+describe('auth session sync and current-user resolution', () => {
+  it(
+    'syncs Better Auth user creation into the app users table with parsed names',
+    { timeout: 10000 },
+    async () => {
+      const t = createConvexTest();
+      const now = Date.now();
+
+      const { authUserId } = await createBetterAuthUser(t, {
+        name: 'Jamie Barber',
+        email: 'jamie@example.com',
+        createdAt: now,
+        updatedAt: now,
+      });
+
+      const syncedUser = await t.run((ctx) =>
+        ctx.db
+          .query('users')
+          .withIndex('by_user_id', (q) => q.eq('id', authUserId))
+          .first()
+      );
+
+      expect(syncedUser).toMatchObject({
+        id: authUserId,
+        email: 'jamie@example.com',
+        role: 'client',
+        name: 'Jamie Barber',
+        firstName: 'Jamie',
+        lastName: 'Barber',
+        createdAt: now,
+        updatedAt: now,
+      });
+    }
+  );
+
+  it('keeps the synced app user in step with Better Auth profile updates', async () => {
+    const t = createConvexTest();
+    const { authUserId, authUser } = await createBetterAuthUser(t, {
+      name: 'Jamie Barber',
+      email: 'jamie@example.com',
+    });
+    const updatedAt = Date.now() + 1000;
+
+    const updatedAuthUser = await t.mutation(components.betterAuth.adapter.updateOne, {
+      input: {
+        model: 'user',
+        where: [{ field: '_id', operator: 'eq', value: authUserId }],
+        update: {
+          name: 'Jordan Admin',
+          email: 'jordan@example.com',
+          updatedAt,
+        },
+      },
+    });
+
+    await t.mutation(internal.auth.onUpdate, {
+      model: 'user',
+      oldDoc: authUser,
+      newDoc: updatedAuthUser,
+    });
+
+    const syncedUser = await t.run((ctx) =>
+      ctx.db
+        .query('users')
+        .withIndex('by_user_id', (q) => q.eq('id', authUserId))
+        .first()
+    );
+
+    expect(syncedUser).toMatchObject({
+      id: authUserId,
+      email: 'jordan@example.com',
+      role: 'client',
+      name: 'Jordan Admin',
+      firstName: 'Jordan',
+      lastName: 'Admin',
+      updatedAt,
+    });
+  });
+
+  it('resolves the synced app user for the current session so app roles win', async () => {
+    const t = createConvexTest();
+    const { identity, authUserId } = await createSyncedAuthIdentity(t, {
+      name: 'Alex Manager',
+      email: 'alex@example.com',
+    });
+
+    await t.run(async (ctx) => {
+      const user = await ctx.db
+        .query('users')
+        .withIndex('by_user_id', (q) => q.eq('id', authUserId))
+        .first();
+
+      if (!user) {
+        throw new Error('Expected synced app user to exist.');
+      }
+
+      await ctx.db.patch(user._id, {
+        role: 'admin',
+      });
+    });
+
+    const currentUser = await t.withIdentity(identity).query(api.auth.getCurrentUser, {});
+
+    expect(currentUser).toMatchObject({
+      id: authUserId,
+      email: 'alex@example.com',
+      role: 'admin',
+      name: 'Alex Manager',
+    });
+  });
+
+  it('falls back to the Better Auth session user when sync has not materialized yet', async () => {
+    const t = createConvexTest();
+    const { identity, authUserId, now } = await createUnsyncedAuthIdentity(t, {
+      name: 'Taylor Client',
+      email: 'taylor@example.com',
+    });
+
+    const currentUser = await t.withIdentity(identity).query(api.auth.getCurrentUser, {});
+
+    expect(currentUser).toMatchObject({
+      id: authUserId,
+      email: 'taylor@example.com',
+      role: 'client',
+      name: 'Taylor Client',
+      firstName: 'Taylor',
+      lastName: 'Client',
+      createdAt: now,
+      updatedAt: now,
+    });
+  });
+
+  it('removes the synced app user when Better Auth deletes the account', async () => {
+    const t = createConvexTest();
+    const { authUserId } = await createBetterAuthUser(t, {
+      name: 'Riley Client',
+      email: 'riley@example.com',
+    });
+
+    const deletedAuthUser = await t.mutation(components.betterAuth.adapter.deleteOne, {
+      input: {
+        model: 'user',
+        where: [{ field: '_id', operator: 'eq', value: authUserId }],
+      },
+    });
+
+    await t.mutation(internal.auth.onDelete, {
+      model: 'user',
+      doc: deletedAuthUser,
+    });
+
+    const syncedUser = await t.run((ctx) =>
+      ctx.db
+        .query('users')
+        .withIndex('by_user_id', (q) => q.eq('id', authUserId))
+        .first()
+    );
+
+    expect(syncedUser).toBeNull();
+  });
+});

--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -1,0 +1,55 @@
+import { expect, test, type Page } from '@playwright/test';
+
+const persistedAuthStorageKey = 'persist:auth';
+
+const stalePersistedAuthState = JSON.stringify({
+  user: JSON.stringify('persisted@example.com'),
+  role: JSON.stringify('client'),
+  _persist: JSON.stringify({ version: -1, rehydrated: true }),
+});
+
+async function mockUnauthenticatedSession(page: Page) {
+  await page.route('**/api/auth/get-session**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: 'null',
+    });
+  });
+}
+
+test('@auth redirects protected routes to login and clears stale persisted auth', async ({
+  page,
+}) => {
+  await page.addInitScript(
+    ({ storageKey, storageValue }) => {
+      window.localStorage.setItem(storageKey, storageValue);
+    },
+    {
+      storageKey: persistedAuthStorageKey,
+      storageValue: stalePersistedAuthState,
+    }
+  );
+  await mockUnauthenticatedSession(page);
+
+  await page.goto('/account?tab=security');
+
+  await expect(page).toHaveURL(
+    /\/login\?returnTo=%2Faccount%3Ftab%3Dsecurity$/
+  );
+  await expect(
+    page.getByRole('heading', { name: /log in/i })
+  ).toBeVisible();
+  await expect(
+    page.locator('form').getByRole('button', { name: /^login$/i })
+  ).toBeVisible();
+
+  await page.waitForFunction((storageKey) => {
+    const persisted = window.localStorage.getItem(storageKey);
+    return (
+      persisted != null &&
+      persisted.includes('"user":"null"') &&
+      persisted.includes('"role":"null"')
+    );
+  }, persistedAuthStorageKey);
+});


### PR DESCRIPTION
## Summary
- add a narrow auth/session adapter seam so auth coordination can be tested without deep hook mocking
- add client integration coverage for protected-route redirect, persisted-auth clearing, loading/settling, and logout failure behavior
- add Convex auth/session integration coverage plus an @auth Playwright spec for the protected-route redirect path

## Testing
- pnpm -C client typecheck
- pnpm -C client test:run
- pnpm -C convex-tests test:run
- pnpm test:e2e -- --grep auth